### PR TITLE
fix: prevent extension heartbeat from stopping randomly

### DIFF
--- a/go/action_kit_sdk/CHANGELOG.md
+++ b/go/action_kit_sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.11
+
+- prevent extension heartbeat processing from stopping randomly
+
 ## 1.1.10
 
 - add possibility to pass callback functions to InstallSignalHandler

--- a/go/action_kit_sdk/action_sdk_integration_test.go
+++ b/go/action_kit_sdk/action_sdk_integration_test.go
@@ -158,7 +158,7 @@ func testcaseHeartbeatTimeout(t *testing.T, op ActionOperations) {
 	state = op.start(t, state)
 	op.resetCalls()
 
-	time.Sleep(20 * time.Second)
+	time.Sleep(25 * time.Second)
 	op.assertCall(t, "Stop", toExampleState(state))
 
 	statusResult := op.statusResult(t, state)

--- a/go/action_kit_sdk/action_sdk_test.go
+++ b/go/action_kit_sdk/action_sdk_test.go
@@ -1,0 +1,40 @@
+package action_kit_sdk
+
+import (
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+// This test reproduced an issue in which new heartbeats
+// would not be processed anymore and led to a stop of the experiment.
+func TestHeartbeat_should_not_timeout(t *testing.T) {
+	stop := make(chan interface{})
+	id, err := uuid.NewUUID()
+	assert.NoError(t, err)
+
+	monitorHeartbeatWithCallback(id, 1*time.Second, 4*time.Second, func() {
+		stop <- nil
+	})
+
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			case <-time.After(1 * time.Second):
+				recordHeartbeat(id)
+			}
+		}
+	}()
+
+	select {
+	case _, ok := <-stop:
+		if ok {
+			assert.Fail(t, "heartbeat close called")
+		}
+	case <-time.After(10 * time.Second):
+		close(stop)
+	}
+}


### PR DESCRIPTION
This issue was caused by a race condition and, hence, hard to attribute to a specific thing. In situations in which the heartbeat was constantly missed, the heartbeat channel was reported as full, so no new messages were added, and no reads from the channel were performed.

This change adds some jitter to reduce missed heartbeats due to network and processing time and changes the heartbeat queue to a buffered one so that new messages can be added.