### PR TITLE
fix: add CAP_DAC_OVERRIDE to fill disk

### DIFF
--- a/go/action_kit_api/go.mod
+++ b/go/action_kit_api/go.mod
@@ -1,6 +1,9 @@
 module github.com/steadybit/action-kit/go/action_kit_api/v2
 
-go 1.22
+go 1.22.5
+
+toolchain go1.23.6
+
 require (
 	github.com/getkin/kin-openapi v0.129.0
 	github.com/google/uuid v1.6.0

--- a/go/action_kit_commons/CHANGELOG.md
+++ b/go/action_kit_commons/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.21
+
+- fix: use CAP_DAC_OVERRIDE in fill disk attacks to ignore file permissions
+
 ## 1.2.20
 
 - fix: properly check file not exist errors during namespace lookup

--- a/go/action_kit_sdk/go.mod
+++ b/go/action_kit_sdk/go.mod
@@ -1,7 +1,8 @@
 module github.com/steadybit/action-kit/go/action_kit_sdk
 
-go 1.22.5
-toolchain go1.23.4
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
In order to ignore file permissions on the target directory for the disk fill attack we need use the CAP_DAC_OVERRIDE. This cap is already added to the extension-container and host anyway.