### PR TITLE
feat: add support for delay attack to delay only on TCP PSH packets

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -7,3 +7,35 @@ There are two common issues causing this:
 1. The agent couldn't (properly) communicate with the extension. To analyze this further, please inspect the agent log.
 2. Your team within Steadybit is not allowed to use the actions. Inspect the team configuration via the Steadybit settings views to
    ensure that the actions are allowed for your team.
+
+## Network Filtering
+
+### Why is my TCP PSH filtering not working as expected?
+
+TCP PSH filtering relies on specific assumptions about network packet structure. Common issues include:
+
+1. **IP Options or IPv6 Extension Headers**: The filtering assumes standard header sizes (20 bytes for IPv4, 40 bytes for IPv6). If your network uses IP options or IPv6 extension headers, the packet offsets will be incorrect.
+
+2. **PSH Flag Not Set**: Some applications or network stacks may not set the PSH flag on data packets. Verify that your test traffic actually has the PSH flag set using `tcpdump`.
+
+3. **Wrong Packet Types**: PSH filtering only affects TCP packets with the PSH flag set and all UDP packets. Control packets (SYN, FIN, ACK-only) typically don't have the PSH flag.
+
+**Troubleshooting steps:**
+- Use `tcpdump -i eth0 -n tcp and port 80` to verify PSH flags
+- Check `tc filter show dev eth0` to verify the rules are applied
+- Test with simple HTTP requests that should generate PSH packets
+
+### Can I use TCP PSH filtering with IPv6?
+
+Yes, TCP PSH filtering supports both IPv4 and IPv6. However, the same packet structure assumptions apply:
+- IPv6 assumes standard 40-byte headers with no extension headers
+- If IPv6 extension headers are present, the filtering offsets will be incorrect
+
+### What happens to UDP packets when TCP PSH filtering is enabled?
+
+When `TcpPshOnly` is enabled:
+- **TCP packets**: Only delayed if they have the PSH flag set
+- **UDP packets**: All UDP packets are delayed (UDP has no PSH equivalent)
+- **Other protocols**: Not affected by the filter
+
+This behavior ensures that both TCP data packets and UDP packets are consistently delayed, providing predictable network behavior for applications using either protocol.

--- a/go/action_kit_commons/CHANGELOG.md
+++ b/go/action_kit_commons/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.5.8
+
+- feat: add support for delay attack to delay only on TCP PSH packets
+
 ## 1.5.7
 
 - fix: correctly reference named network namespace in ip netns exec calls

--- a/go/action_kit_commons/network/delay.go
+++ b/go/action_kit_commons/network/delay.go
@@ -32,9 +32,7 @@ func (o *DelayOpts) TcCommands(mode Mode) ([]string, error) {
 		cmds = append(cmds, fmt.Sprintf("qdisc %s dev %s root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0", mode, ifc))
 		cmds = append(cmds, fmt.Sprintf("qdisc %s dev %s parent %s handle 30: netem delay %dms %dms", mode, ifc, handleInclude, o.Delay.Milliseconds(), o.Jitter.Milliseconds()))
 
-		var filterCmds []string
-		var err error
-		filterCmds, err = tcCommandsForDelayFilter(mode, filter, ifc, o.TcpPshOnly)
+		filterCmds, err := tcCommandsForDelayFilter(mode, filter, ifc, o.TcpPshOnly)
 		if err != nil {
 			return nil, err
 		}

--- a/go/action_kit_commons/network/delay_test.go
+++ b/go/action_kit_commons/network/delay_test.go
@@ -5,10 +5,11 @@
 package network
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"testing/iotest"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDelayOpts_TcCommands(t *testing.T) {
@@ -130,6 +131,151 @@ qdisc del dev eth0 root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
 `),
 			wantErr: false,
 		},
+		{
+			name: "delay with TCP PSH flag filtering",
+			opts: DelayOpts{
+				Filter: Filter{
+					Include: []NetWithPortRange{
+						mustParseNetWithPortRange("192.168.1.0/24", "80"),
+						mustParseNetWithPortRange("10.0.0.0/8", "443"),
+					},
+				},
+				Delay:      200 * time.Millisecond,
+				Jitter:     20 * time.Millisecond,
+				Interfaces: []string{"eth0"},
+				TcpPshOnly: true,
+			},
+			wantAdd: []byte(`qdisc add dev eth0 root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+qdisc add dev eth0 parent 1:3 handle 30: netem delay 200ms 20ms
+filter add dev eth0 protocol ip parent 1: prio 1 u32 match ip protocol 6 0xff match ip src 10.0.0.0/8 match u16 443 0xffff at 20 match u8 0x08 0x08 at 33 flowid 1:3
+filter add dev eth0 protocol ip parent 1: prio 2 u32 match ip protocol 6 0xff match ip dst 10.0.0.0/8 match u16 443 0xffff at 22 match u8 0x08 0x08 at 33 flowid 1:3
+filter add dev eth0 protocol ip parent 1: prio 3 u32 match ip protocol 17 0xff match ip src 10.0.0.0/8 match u16 443 0xffff at 20 flowid 1:3
+filter add dev eth0 protocol ip parent 1: prio 4 u32 match ip protocol 17 0xff match ip dst 10.0.0.0/8 match u16 443 0xffff at 22 flowid 1:3
+filter add dev eth0 protocol ip parent 1: prio 5 u32 match ip protocol 6 0xff match ip src 192.168.1.0/24 match u16 80 0xffff at 20 match u8 0x08 0x08 at 33 flowid 1:3
+filter add dev eth0 protocol ip parent 1: prio 6 u32 match ip protocol 6 0xff match ip dst 192.168.1.0/24 match u16 80 0xffff at 22 match u8 0x08 0x08 at 33 flowid 1:3
+filter add dev eth0 protocol ip parent 1: prio 7 u32 match ip protocol 17 0xff match ip src 192.168.1.0/24 match u16 80 0xffff at 20 flowid 1:3
+filter add dev eth0 protocol ip parent 1: prio 8 u32 match ip protocol 17 0xff match ip dst 192.168.1.0/24 match u16 80 0xffff at 22 flowid 1:3
+`),
+			wantDel: []byte(`filter del dev eth0 protocol ip parent 1: prio 8 u32 match ip protocol 17 0xff match ip dst 192.168.1.0/24 match u16 80 0xffff at 22 flowid 1:3
+filter del dev eth0 protocol ip parent 1: prio 7 u32 match ip protocol 17 0xff match ip src 192.168.1.0/24 match u16 80 0xffff at 20 flowid 1:3
+filter del dev eth0 protocol ip parent 1: prio 6 u32 match ip protocol 6 0xff match ip dst 192.168.1.0/24 match u16 80 0xffff at 22 match u8 0x08 0x08 at 33 flowid 1:3
+filter del dev eth0 protocol ip parent 1: prio 5 u32 match ip protocol 6 0xff match ip src 192.168.1.0/24 match u16 80 0xffff at 20 match u8 0x08 0x08 at 33 flowid 1:3
+filter del dev eth0 protocol ip parent 1: prio 4 u32 match ip protocol 17 0xff match ip dst 10.0.0.0/8 match u16 443 0xffff at 22 flowid 1:3
+filter del dev eth0 protocol ip parent 1: prio 3 u32 match ip protocol 17 0xff match ip src 10.0.0.0/8 match u16 443 0xffff at 20 flowid 1:3
+filter del dev eth0 protocol ip parent 1: prio 2 u32 match ip protocol 6 0xff match ip dst 10.0.0.0/8 match u16 443 0xffff at 22 match u8 0x08 0x08 at 33 flowid 1:3
+filter del dev eth0 protocol ip parent 1: prio 1 u32 match ip protocol 6 0xff match ip src 10.0.0.0/8 match u16 443 0xffff at 20 match u8 0x08 0x08 at 33 flowid 1:3
+qdisc del dev eth0 parent 1:3 handle 30: netem delay 200ms 20ms
+qdisc del dev eth0 root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+`),
+			wantErr: false,
+		},
+		{
+			name: "delay with TCP PSH flag filtering and IPv6",
+			opts: DelayOpts{
+				Filter: Filter{
+					Include: []NetWithPortRange{
+						mustParseNetWithPortRange("2001:db8::/32", "8080"),
+					},
+				},
+				Delay:      150 * time.Millisecond,
+				Jitter:     15 * time.Millisecond,
+				Interfaces: []string{"eth0"},
+				TcpPshOnly: true,
+			},
+			wantAdd: []byte(`qdisc add dev eth0 root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+qdisc add dev eth0 parent 1:3 handle 30: netem delay 150ms 15ms
+filter add dev eth0 protocol ipv6 parent 1: prio 1 u32 match ip6 nexthdr 6 0xff match ip6 src 2001:db8::/32 match u16 8080 0xffff at 40 match u8 0x08 0x08 at 53 flowid 1:3
+filter add dev eth0 protocol ipv6 parent 1: prio 2 u32 match ip6 nexthdr 6 0xff match ip6 dst 2001:db8::/32 match u16 8080 0xffff at 42 match u8 0x08 0x08 at 53 flowid 1:3
+filter add dev eth0 protocol ipv6 parent 1: prio 3 u32 match ip6 nexthdr 17 0xff match ip6 src 2001:db8::/32 match u16 8080 0xffff at 40 flowid 1:3
+filter add dev eth0 protocol ipv6 parent 1: prio 4 u32 match ip6 nexthdr 17 0xff match ip6 dst 2001:db8::/32 match u16 8080 0xffff at 42 flowid 1:3
+`),
+			wantDel: []byte(`filter del dev eth0 protocol ipv6 parent 1: prio 4 u32 match ip6 nexthdr 17 0xff match ip6 dst 2001:db8::/32 match u16 8080 0xffff at 42 flowid 1:3
+filter del dev eth0 protocol ipv6 parent 1: prio 3 u32 match ip6 nexthdr 17 0xff match ip6 src 2001:db8::/32 match u16 8080 0xffff at 40 flowid 1:3
+filter del dev eth0 protocol ipv6 parent 1: prio 2 u32 match ip6 nexthdr 6 0xff match ip6 dst 2001:db8::/32 match u16 8080 0xffff at 42 match u8 0x08 0x08 at 53 flowid 1:3
+filter del dev eth0 protocol ipv6 parent 1: prio 1 u32 match ip6 nexthdr 6 0xff match ip6 src 2001:db8::/32 match u16 8080 0xffff at 40 match u8 0x08 0x08 at 53 flowid 1:3
+qdisc del dev eth0 parent 1:3 handle 30: netem delay 150ms 15ms
+qdisc del dev eth0 root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+`),
+			wantErr: false,
+		},
+		{
+			name: "delay with TCP PSH flag filtering and port ranges",
+			opts: DelayOpts{
+				Filter: Filter{
+					Include: []NetWithPortRange{
+						mustParseNetWithPortRange("192.168.1.0/24", "80-85"),
+					},
+				},
+				Delay:      100 * time.Millisecond,
+				Jitter:     10 * time.Millisecond,
+				Interfaces: []string{"eth0"},
+				TcpPshOnly: true,
+			},
+			wantAdd: []byte(`qdisc add dev eth0 root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+qdisc add dev eth0 parent 1:3 handle 30: netem delay 100ms 10ms
+filter add dev eth0 protocol ip parent 1: prio 1 u32 match ip protocol 6 0xff match ip src 192.168.1.0/24 match u16 80 0xfffc at 20 match u8 0x08 0x08 at 33 flowid 1:3
+filter add dev eth0 protocol ip parent 1: prio 2 u32 match ip protocol 6 0xff match ip dst 192.168.1.0/24 match u16 80 0xfffc at 22 match u8 0x08 0x08 at 33 flowid 1:3
+filter add dev eth0 protocol ip parent 1: prio 3 u32 match ip protocol 17 0xff match ip src 192.168.1.0/24 match u16 80 0xfffc at 20 flowid 1:3
+filter add dev eth0 protocol ip parent 1: prio 4 u32 match ip protocol 17 0xff match ip dst 192.168.1.0/24 match u16 80 0xfffc at 22 flowid 1:3
+filter add dev eth0 protocol ip parent 1: prio 5 u32 match ip protocol 6 0xff match ip src 192.168.1.0/24 match u16 84 0xfffe at 20 match u8 0x08 0x08 at 33 flowid 1:3
+filter add dev eth0 protocol ip parent 1: prio 6 u32 match ip protocol 6 0xff match ip dst 192.168.1.0/24 match u16 84 0xfffe at 22 match u8 0x08 0x08 at 33 flowid 1:3
+filter add dev eth0 protocol ip parent 1: prio 7 u32 match ip protocol 17 0xff match ip src 192.168.1.0/24 match u16 84 0xfffe at 20 flowid 1:3
+filter add dev eth0 protocol ip parent 1: prio 8 u32 match ip protocol 17 0xff match ip dst 192.168.1.0/24 match u16 84 0xfffe at 22 flowid 1:3
+`),
+			wantDel: []byte(`filter del dev eth0 protocol ip parent 1: prio 8 u32 match ip protocol 17 0xff match ip dst 192.168.1.0/24 match u16 84 0xfffe at 22 flowid 1:3
+filter del dev eth0 protocol ip parent 1: prio 7 u32 match ip protocol 17 0xff match ip src 192.168.1.0/24 match u16 84 0xfffe at 20 flowid 1:3
+filter del dev eth0 protocol ip parent 1: prio 6 u32 match ip protocol 6 0xff match ip dst 192.168.1.0/24 match u16 84 0xfffe at 22 match u8 0x08 0x08 at 33 flowid 1:3
+filter del dev eth0 protocol ip parent 1: prio 5 u32 match ip protocol 6 0xff match ip src 192.168.1.0/24 match u16 84 0xfffe at 20 match u8 0x08 0x08 at 33 flowid 1:3
+filter del dev eth0 protocol ip parent 1: prio 4 u32 match ip protocol 17 0xff match ip dst 192.168.1.0/24 match u16 80 0xfffc at 22 flowid 1:3
+filter del dev eth0 protocol ip parent 1: prio 3 u32 match ip protocol 17 0xff match ip src 192.168.1.0/24 match u16 80 0xfffc at 20 flowid 1:3
+filter del dev eth0 protocol ip parent 1: prio 2 u32 match ip protocol 6 0xff match ip dst 192.168.1.0/24 match u16 80 0xfffc at 22 match u8 0x08 0x08 at 33 flowid 1:3
+filter del dev eth0 protocol ip parent 1: prio 1 u32 match ip protocol 6 0xff match ip src 192.168.1.0/24 match u16 80 0xfffc at 20 match u8 0x08 0x08 at 33 flowid 1:3
+qdisc del dev eth0 parent 1:3 handle 30: netem delay 100ms 10ms
+qdisc del dev eth0 root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+`),
+			wantErr: false,
+		},
+		{
+			name: "delay with TCP PSH flag filtering and multiple interfaces",
+			opts: DelayOpts{
+				Filter: Filter{
+					Include: []NetWithPortRange{
+						mustParseNetWithPortRange("192.168.1.0/24", "80"),
+					},
+				},
+				Delay:      100 * time.Millisecond,
+				Jitter:     10 * time.Millisecond,
+				Interfaces: []string{"eth0", "eth1"},
+				TcpPshOnly: true,
+			},
+			wantAdd: []byte(`qdisc add dev eth0 root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+qdisc add dev eth0 parent 1:3 handle 30: netem delay 100ms 10ms
+filter add dev eth0 protocol ip parent 1: prio 1 u32 match ip protocol 6 0xff match ip src 192.168.1.0/24 match u16 80 0xffff at 20 match u8 0x08 0x08 at 33 flowid 1:3
+filter add dev eth0 protocol ip parent 1: prio 2 u32 match ip protocol 6 0xff match ip dst 192.168.1.0/24 match u16 80 0xffff at 22 match u8 0x08 0x08 at 33 flowid 1:3
+filter add dev eth0 protocol ip parent 1: prio 3 u32 match ip protocol 17 0xff match ip src 192.168.1.0/24 match u16 80 0xffff at 20 flowid 1:3
+filter add dev eth0 protocol ip parent 1: prio 4 u32 match ip protocol 17 0xff match ip dst 192.168.1.0/24 match u16 80 0xffff at 22 flowid 1:3
+qdisc add dev eth1 root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+qdisc add dev eth1 parent 1:3 handle 30: netem delay 100ms 10ms
+filter add dev eth1 protocol ip parent 1: prio 1 u32 match ip protocol 6 0xff match ip src 192.168.1.0/24 match u16 80 0xffff at 20 match u8 0x08 0x08 at 33 flowid 1:3
+filter add dev eth1 protocol ip parent 1: prio 2 u32 match ip protocol 6 0xff match ip dst 192.168.1.0/24 match u16 80 0xffff at 22 match u8 0x08 0x08 at 33 flowid 1:3
+filter add dev eth1 protocol ip parent 1: prio 3 u32 match ip protocol 17 0xff match ip src 192.168.1.0/24 match u16 80 0xffff at 20 flowid 1:3
+filter add dev eth1 protocol ip parent 1: prio 4 u32 match ip protocol 17 0xff match ip dst 192.168.1.0/24 match u16 80 0xffff at 22 flowid 1:3
+`),
+			wantDel: []byte(`filter del dev eth1 protocol ip parent 1: prio 4 u32 match ip protocol 17 0xff match ip dst 192.168.1.0/24 match u16 80 0xffff at 22 flowid 1:3
+filter del dev eth1 protocol ip parent 1: prio 3 u32 match ip protocol 17 0xff match ip src 192.168.1.0/24 match u16 80 0xffff at 20 flowid 1:3
+filter del dev eth1 protocol ip parent 1: prio 2 u32 match ip protocol 6 0xff match ip dst 192.168.1.0/24 match u16 80 0xffff at 22 match u8 0x08 0x08 at 33 flowid 1:3
+filter del dev eth1 protocol ip parent 1: prio 1 u32 match ip protocol 6 0xff match ip src 192.168.1.0/24 match u16 80 0xffff at 20 match u8 0x08 0x08 at 33 flowid 1:3
+qdisc del dev eth1 parent 1:3 handle 30: netem delay 100ms 10ms
+qdisc del dev eth1 root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+filter del dev eth0 protocol ip parent 1: prio 4 u32 match ip protocol 17 0xff match ip dst 192.168.1.0/24 match u16 80 0xffff at 22 flowid 1:3
+filter del dev eth0 protocol ip parent 1: prio 3 u32 match ip protocol 17 0xff match ip src 192.168.1.0/24 match u16 80 0xffff at 20 flowid 1:3
+filter del dev eth0 protocol ip parent 1: prio 2 u32 match ip protocol 6 0xff match ip dst 192.168.1.0/24 match u16 80 0xffff at 22 match u8 0x08 0x08 at 33 flowid 1:3
+filter del dev eth0 protocol ip parent 1: prio 1 u32 match ip protocol 6 0xff match ip src 192.168.1.0/24 match u16 80 0xffff at 20 match u8 0x08 0x08 at 33 flowid 1:3
+qdisc del dev eth0 parent 1:3 handle 30: netem delay 100ms 10ms
+qdisc del dev eth0 root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+`),
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -159,6 +305,157 @@ qdisc del dev eth0 root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
 				}
 			} else {
 				assert.NoError(t, iotest.TestReader(ToReader(gotDel), tt.wantDel))
+			}
+		})
+	}
+}
+
+func TestDelayOpts_String(t *testing.T) {
+	tests := []struct {
+		name string
+		opts DelayOpts
+		want string
+	}{
+		{
+			name: "delay without PSH flag",
+			opts: DelayOpts{
+				Filter: Filter{
+					Include: []NetWithPortRange{
+						mustParseNetWithPortRange("192.168.1.0/24", "80"),
+					},
+				},
+				Delay:      100 * time.Millisecond,
+				Jitter:     10 * time.Millisecond,
+				Interfaces: []string{"eth0"},
+				TcpPshOnly: false,
+			},
+			want: "delaying traffic by 100ms (jitter: 10ms, interfaces: eth0) including 192.168.1.0/24:80",
+		},
+		{
+			name: "delay with PSH flag",
+			opts: DelayOpts{
+				Filter: Filter{
+					Include: []NetWithPortRange{
+						mustParseNetWithPortRange("192.168.1.0/24", "80"),
+					},
+				},
+				Delay:      100 * time.Millisecond,
+				Jitter:     10 * time.Millisecond,
+				Interfaces: []string{"eth0"},
+				TcpPshOnly: true,
+			},
+			want: "delaying traffic by 100ms (jitter: 10ms, interfaces: eth0) including 192.168.1.0/24:80",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.opts.String(); got != tt.want {
+				t.Errorf("String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetMatchersForDelay(t *testing.T) {
+	tests := []struct {
+		name         string
+		nwp          NetWithPortRange
+		tcpPshOnly   bool
+		wantMatchers []string
+		wantErr      bool
+	}{
+		{
+			name:       "IPv4 without PSH flag",
+			nwp:        mustParseNetWithPortRange("192.168.1.0/24", "80"),
+			tcpPshOnly: false,
+			wantMatchers: []string{
+				"match ip src 192.168.1.0/24 match ip sport 80 0xffff",
+				"match ip dst 192.168.1.0/24 match ip dport 80 0xffff",
+			},
+			wantErr: false,
+		},
+		{
+			name:       "IPv4 with PSH flag",
+			nwp:        mustParseNetWithPortRange("192.168.1.0/24", "80"),
+			tcpPshOnly: true,
+			wantMatchers: []string{
+				"match ip protocol 6 0xff match ip src 192.168.1.0/24 match u16 80 0xffff at 20 match u8 0x08 0x08 at 33",
+				"match ip protocol 6 0xff match ip dst 192.168.1.0/24 match u16 80 0xffff at 22 match u8 0x08 0x08 at 33",
+				"match ip protocol 17 0xff match ip src 192.168.1.0/24 match u16 80 0xffff at 20",
+				"match ip protocol 17 0xff match ip dst 192.168.1.0/24 match u16 80 0xffff at 22",
+			},
+			wantErr: false,
+		},
+		{
+			name:       "IPv6 with PSH flag",
+			nwp:        mustParseNetWithPortRange("2001:db8::/32", "8080"),
+			tcpPshOnly: true,
+			wantMatchers: []string{
+				"match ip6 nexthdr 6 0xff match ip6 src 2001:db8::/32 match u16 8080 0xffff at 40 match u8 0x08 0x08 at 53",
+				"match ip6 nexthdr 6 0xff match ip6 dst 2001:db8::/32 match u16 8080 0xffff at 42 match u8 0x08 0x08 at 53",
+				"match ip6 nexthdr 17 0xff match ip6 src 2001:db8::/32 match u16 8080 0xffff at 40",
+				"match ip6 nexthdr 17 0xff match ip6 dst 2001:db8::/32 match u16 8080 0xffff at 42",
+			},
+			wantErr: false,
+		},
+		{
+			name:       "IPv4 with PSH flag and port range",
+			nwp:        mustParseNetWithPortRange("192.168.1.0/24", "80-82"),
+			tcpPshOnly: true,
+			wantMatchers: []string{
+				"match ip protocol 6 0xff match ip src 192.168.1.0/24 match u16 80 0xfffe at 20 match u8 0x08 0x08 at 33",
+				"match ip protocol 6 0xff match ip dst 192.168.1.0/24 match u16 80 0xfffe at 22 match u8 0x08 0x08 at 33",
+				"match ip protocol 17 0xff match ip src 192.168.1.0/24 match u16 80 0xfffe at 20",
+				"match ip protocol 17 0xff match ip dst 192.168.1.0/24 match u16 80 0xfffe at 22",
+				"match ip protocol 6 0xff match ip src 192.168.1.0/24 match u16 82 0xffff at 20 match u8 0x08 0x08 at 33",
+				"match ip protocol 6 0xff match ip dst 192.168.1.0/24 match u16 82 0xffff at 22 match u8 0x08 0x08 at 33",
+				"match ip protocol 17 0xff match ip src 192.168.1.0/24 match u16 82 0xffff at 20",
+				"match ip protocol 17 0xff match ip dst 192.168.1.0/24 match u16 82 0xffff at 22",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMatchers, err := getMatchersForDelay(tt.nwp, tt.tcpPshOnly)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getMatchersForDelay() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !assert.Equal(t, tt.wantMatchers, gotMatchers) {
+				t.Errorf("getMatchersForDelay() = %v, want %v", gotMatchers, tt.wantMatchers)
+			}
+		})
+	}
+}
+
+func TestGetTcpPortOffsets(t *testing.T) {
+	tests := []struct {
+		name    string
+		family  Family
+		wantSrc int
+		wantDst int
+	}{
+		{
+			name:    "IPv4",
+			family:  FamilyV4,
+			wantSrc: 20,
+			wantDst: 22,
+		},
+		{
+			name:    "IPv6",
+			family:  FamilyV6,
+			wantSrc: 40,
+			wantDst: 42,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getTcpSrcPortOffset(tt.family); got != tt.wantSrc {
+				t.Errorf("getTcpSrcPortOffset() = %v, want %v", got, tt.wantSrc)
+			}
+			if got := getTcpDstPortOffset(tt.family); got != tt.wantDst {
+				t.Errorf("getTcpDstPortOffset() = %v, want %v", got, tt.wantDst)
 			}
 		})
 	}


### PR DESCRIPTION
Add option for delaying only TCP PSH flag packets. This is a heuristic based approach to delaying only TCP data packets which makes delay injection more accurate for real world tests for distributed systems where we can not perform L7 delay.