### PR TITLE
fix(netfault): replace root qdisc instead of add to support pre-existing qdiscs

### DIFF
--- a/go/action_kit_commons/CHANGELOG.md
+++ b/go/action_kit_commons/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 1.8.0
+
+- netfault: use `tc qdisc replace` (instead of `add`) for the root qdisc in
+  delay/loss/corruption/bandwidth attacks so they no longer fail on hosts
+  with a pre-existing root qdisc (e.g. `mq` on GKE COS / EKS / AKS).
+- netfault: add preflight check that warns when an interface has a
+  user-installed root qdisc (anything other than `mq`, `noqueue`,
+  `pfifo_fast`, `fq_codel`, `fq`); the kernel default will be restored
+  after revert in that case.
+- **Breaking:** `netfault.Apply` now returns `([]string, error)` — the
+  string slice contains preflight warnings to surface to the user.
+- **Breaking:** The `Opts` interface no longer requires `ipCommands` or
+  `tcCommands`. Subsystem behavior is now opt-in via two new optional
+  interfaces: `tcCommandProvider` (`tcCommands` + `tcRootQdiscInterfaces`)
+  and `ipCommandProvider` (`ipCommands`), mirroring the existing
+  `iptablesScriptProvider`. External `Opts` implementations that returned
+  `nil, nil` from these methods can simply remove them; external callers
+  that consumed those methods need a type assertion first.
+
 ## 1.6.1
 
 - Add UseMangleChain to TcpResetOpts to enable tcp reset on istio

--- a/go/action_kit_commons/network/netfault/bandwidth.go
+++ b/go/action_kit_commons/network/netfault/bandwidth.go
@@ -46,8 +46,8 @@ func (o *LimitBandwidthOpts) doesConflictWith(opts Opts) bool {
 	return false
 }
 
-func (o *LimitBandwidthOpts) ipCommands(_ family, _ mode) ([]string, error) {
-	return nil, nil
+func (o *LimitBandwidthOpts) tcRootQdiscInterfaces() []string {
+	return o.Interfaces
 }
 
 func (o *LimitBandwidthOpts) tcCommands(mode mode) ([]string, error) {
@@ -63,7 +63,7 @@ func (o *LimitBandwidthOpts) tcCommands(mode mode) ([]string, error) {
 
 	filter := optimizeFilter(o.Filter)
 	for _, ifc := range o.Interfaces {
-		cmds = append(cmds, fmt.Sprintf("qdisc %s dev %s root handle 1: htb default 30", mode, ifc))
+		cmds = append(cmds, fmt.Sprintf("qdisc %s dev %s root handle 1: htb default 30", rootQdiscVerb(mode), ifc))
 		cmds = append(cmds, fmt.Sprintf("class %s dev %s parent 1: classid %s htb rate %s", mode, ifc, handleInclude, o.Bandwidth))
 
 		filterCmds, err := tcCommandsForFilter(mode, filter, ifc)

--- a/go/action_kit_commons/network/netfault/bandwidth_test.go
+++ b/go/action_kit_commons/network/netfault/bandwidth_test.go
@@ -61,7 +61,7 @@ func TestLimitBandwidthOpts_TcCommands(t *testing.T) {
 				Bandwidth:  "100mbit",
 				Interfaces: []string{"eth0"},
 			},
-			wantAdd: []byte(`qdisc add dev eth0 root handle 1: htb default 30
+			wantAdd: []byte(`qdisc replace dev eth0 root handle 1: htb default 30
 class add dev eth0 parent 1: classid 1:3 htb rate 100mbit
 filter add dev eth0 protocol ip parent 1: prio 1 u32 match ip src 192.168.2.1/32 match ip sport 80 0xffff flowid 1:1
 filter add dev eth0 protocol ip parent 1: prio 2 u32 match ip dst 192.168.2.1/32 match ip dport 80 0xffff flowid 1:1

--- a/go/action_kit_commons/network/netfault/blackhole.go
+++ b/go/action_kit_commons/network/netfault/blackhole.go
@@ -83,10 +83,6 @@ func (o *BlackholeOpts) ipCommands(family family, mode mode) ([]string, error) {
 	return cmds, nil
 }
 
-func (o *BlackholeOpts) tcCommands(_ mode) ([]string, error) {
-	return nil, nil
-}
-
 func (o *BlackholeOpts) String() string {
 	var sb strings.Builder
 	sb.WriteString("blocking traffic ")

--- a/go/action_kit_commons/network/netfault/delay.go
+++ b/go/action_kit_commons/network/netfault/delay.go
@@ -59,8 +59,8 @@ func (o *DelayOpts) doesConflictWith(opts Opts) bool {
 	return false
 }
 
-func (o *DelayOpts) ipCommands(_ family, _ mode) ([]string, error) {
-	return nil, nil
+func (o *DelayOpts) tcRootQdiscInterfaces() []string {
+	return o.Interfaces
 }
 
 const steadybitDelayFwMark uint32 = 0x1
@@ -174,7 +174,7 @@ func (o *DelayOpts) tcCommands(mode mode) ([]string, error) {
 
 	filter := optimizeFilter(o.Filter)
 	for _, ifc := range o.Interfaces {
-		cmds = append(cmds, fmt.Sprintf("qdisc %s dev %s root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0", mode, ifc))
+		cmds = append(cmds, fmt.Sprintf("qdisc %s dev %s root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0", rootQdiscVerb(mode), ifc))
 		cmds = append(cmds, fmt.Sprintf("qdisc %s dev %s parent %s handle 30: netem delay %dms %dms", mode, ifc, handleInclude, o.Delay.Milliseconds(), o.Jitter.Milliseconds()))
 
 		if o.TcpPshOnly {

--- a/go/action_kit_commons/network/netfault/delay_test.go
+++ b/go/action_kit_commons/network/netfault/delay_test.go
@@ -55,7 +55,7 @@ func TestDelayOpts_TcCommands(t *testing.T) {
 				Jitter:     10 * time.Millisecond,
 				Interfaces: []string{"eth0"},
 			},
-			wantAdd: []byte(`qdisc add dev eth0 root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+			wantAdd: []byte(`qdisc replace dev eth0 root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
 qdisc add dev eth0 parent 1:3 handle 30: netem delay 100ms 10ms
 filter add dev eth0 protocol ip parent 1: prio 1 u32 match ip src 192.168.2.1/32 match ip sport 80 0xffff flowid 1:1
 filter add dev eth0 protocol ip parent 1: prio 2 u32 match ip dst 192.168.2.1/32 match ip dport 80 0xffff flowid 1:1
@@ -112,7 +112,7 @@ qdisc del dev eth0 root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
 				Interfaces: []string{"eth0"},
 				TcpPshOnly: true,
 			},
-			wantAdd: []byte(`qdisc add dev eth0 root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+			wantAdd: []byte(`qdisc replace dev eth0 root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
 qdisc add dev eth0 parent 1:3 handle 30: netem delay 100ms 10ms
 filter add dev eth0 protocol ip parent 1: prio 1 handle 0x1 fw flowid 1:3
 filter add dev eth0 protocol ipv6 parent 1: prio 2 handle 0x1 fw flowid 1:3
@@ -141,7 +141,7 @@ qdisc del dev eth0 root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
 				Jitter:     10 * time.Millisecond,
 				Interfaces: []string{"eth0"},
 			},
-			wantAdd: []byte(`qdisc add dev eth0 root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+			wantAdd: []byte(`qdisc replace dev eth0 root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
 qdisc add dev eth0 parent 1:3 handle 30: netem delay 100ms 10ms
 filter add dev eth0 protocol ip parent 1: prio 1 u32 match ip src 192.168.2.1/32 match ip sport 80 0xffff flowid 1:1
 filter add dev eth0 protocol ip parent 1: prio 2 u32 match ip dst 192.168.2.1/32 match ip dport 80 0xffff flowid 1:1

--- a/go/action_kit_commons/network/netfault/netfault.go
+++ b/go/action_kit_commons/network/netfault/netfault.go
@@ -42,8 +42,18 @@ type CommandRunner interface {
 	id() string
 }
 
-func Apply(ctx context.Context, runner CommandRunner, opts Opts) error {
-	return generateAndRunCommands(ctx, runner, opts, modeAdd)
+// Apply installs the attack. The returned warnings describe pre-existing
+// root qdiscs that the kernel will not auto-restore on Revert.
+func Apply(ctx context.Context, runner CommandRunner, opts Opts) ([]string, error) {
+	var interfaces []string
+	if p, ok := opts.(tcCommandProvider); ok {
+		interfaces = p.tcRootQdiscInterfaces()
+	}
+	warnings := preflightWarnings(ctx, runner, interfaces)
+	if err := generateAndRunCommands(ctx, runner, opts, modeAdd); err != nil {
+		return warnings, err
+	}
+	return warnings, nil
 }
 
 func Revert(ctx context.Context, runner CommandRunner, opts Opts) error {
@@ -51,22 +61,24 @@ func Revert(ctx context.Context, runner CommandRunner, opts Opts) error {
 }
 
 func generateAndRunCommands(ctx context.Context, runner CommandRunner, opts Opts, mode mode) error {
-	ipCommandsV4, err := opts.ipCommands(familyV4, mode)
-	if err != nil {
-		return err
-	}
+	var ipCommandsV4, ipCommandsV6, tcCommands []string
+	var err error
 
-	var ipCommandsV6 []string
-	if ipv6Supported() {
-		ipCommandsV6, err = opts.ipCommands(familyV6, mode)
-		if err != nil {
+	if p, ok := opts.(ipCommandProvider); ok {
+		if ipCommandsV4, err = p.ipCommands(familyV4, mode); err != nil {
 			return err
+		}
+		if ipv6Supported() {
+			if ipCommandsV6, err = p.ipCommands(familyV6, mode); err != nil {
+				return err
+			}
 		}
 	}
 
-	tcCommands, err := opts.tcCommands(mode)
-	if err != nil {
-		return err
+	if p, ok := opts.(tcCommandProvider); ok {
+		if tcCommands, err = p.tcCommands(mode); err != nil {
+			return err
+		}
 	}
 
 	if log.Debug().Enabled() {

--- a/go/action_kit_commons/network/netfault/netfault.go
+++ b/go/action_kit_commons/network/netfault/netfault.go
@@ -42,18 +42,68 @@ type CommandRunner interface {
 	id() string
 }
 
-// Apply installs the attack. The returned warnings describe pre-existing
-// root qdiscs that the kernel will not auto-restore on Revert.
-func Apply(ctx context.Context, runner CommandRunner, opts Opts) ([]string, error) {
-	var interfaces []string
-	if p, ok := opts.(tcCommandProvider); ok {
-		interfaces = p.tcRootQdiscInterfaces()
+// Apply installs the attack.
+func Apply(ctx context.Context, runner CommandRunner, opts Opts) error {
+	return generateAndRunCommands(ctx, runner, opts, modeAdd)
+}
+
+// ErrUserRootQdisc reports that a target interface already carries a
+// user- or CNI-installed root qdisc that the attack would have to destroy.
+type ErrUserRootQdisc struct {
+	Interface string
+	Kind      string
+}
+
+func (e *ErrUserRootQdisc) Error() string {
+	return fmt.Sprintf("interface %q already has a non-default root qdisc %q; the network attack would have to replace it and cannot restore it afterwards. Remove the existing qdisc or exclude this interface from the attack.", e.Interface, e.Kind)
+}
+
+// PreflightCheck inspects the root qdiscs of the interfaces the attack installs
+// its own root qdisc on and returns an *ErrUserRootQdisc when any carries a
+// non-default (user/CNI-installed) qdisc. It is meant to be called from the
+// attack's Prepare step so the experiment fails fast and cleanly without
+// touching the host.
+//
+// Kernel-default root qdiscs (mq/noqueue/fq_codel/fq/pfifo_fast) are accepted:
+// `tc qdisc replace` grafts over them at Start and the kernel restores them on
+// revert. If a steadybit attack is already active on the same network
+// namespace the existing root qdisc is ours, so the check is skipped and the
+// apply-time conflict detection decides whether the attacks may coexist.
+func PreflightCheck(ctx context.Context, runner CommandRunner, opts Opts) error {
+	p, ok := opts.(tcCommandProvider)
+	if !ok {
+		return nil
 	}
-	warnings := preflightWarnings(ctx, runner, interfaces)
-	if err := generateAndRunCommands(ctx, runner, opts, modeAdd); err != nil {
-		return warnings, err
+	interfaces := p.tcRootQdiscInterfaces()
+	if len(interfaces) == 0 {
+		return nil
 	}
-	return warnings, nil
+	if hasActiveNetfault(runner.id()) {
+		return nil
+	}
+
+	kinds, err := inspectRootQdiscs(ctx, runner)
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to inspect root qdiscs; skipping preflight check")
+		return nil
+	}
+	for _, ifc := range interfaces {
+		kind := kinds[ifc]
+		if kind == "" {
+			continue
+		}
+		if _, safe := safeRootQdiscKinds[kind]; safe {
+			continue
+		}
+		return &ErrUserRootQdisc{Interface: ifc, Kind: kind}
+	}
+	return nil
+}
+
+func hasActiveNetfault(netNsId string) bool {
+	activeNetfaultLock.Lock()
+	defer activeNetfaultLock.Unlock()
+	return len(activeNetfault[netNsId]) > 0
 }
 
 func Revert(ctx context.Context, runner CommandRunner, opts Opts) error {

--- a/go/action_kit_commons/network/netfault/netfault.go
+++ b/go/action_kit_commons/network/netfault/netfault.go
@@ -48,14 +48,17 @@ func Apply(ctx context.Context, runner CommandRunner, opts Opts) error {
 }
 
 // ErrUserRootQdisc reports that a target interface already carries a
-// user- or CNI-installed root qdisc that the attack would have to destroy.
+// pre-existing root qdisc that the attack will not replace under the active
+// configuration (a user/CNI qdisc such as `htb`/`cake` by default, or — when
+// SetStrictRootQdisc is enabled — anything other than `noqueue`, including the
+// kernel default `mq`).
 type ErrUserRootQdisc struct {
 	Interface string
 	Kind      string
 }
 
 func (e *ErrUserRootQdisc) Error() string {
-	return fmt.Sprintf("interface %q already has a non-default root qdisc %q; the network attack would have to replace it and cannot restore it afterwards. Remove the existing qdisc or exclude this interface from the attack.", e.Interface, e.Kind)
+	return fmt.Sprintf("interface %q already has a root qdisc %q that the network attack will not replace under the current configuration. Remove the existing qdisc or exclude this interface from the attack.", e.Interface, e.Kind)
 }
 
 // PreflightCheck inspects the root qdiscs of the interfaces the attack installs
@@ -92,7 +95,7 @@ func PreflightCheck(ctx context.Context, runner CommandRunner, opts Opts) error 
 		if kind == "" {
 			continue
 		}
-		if _, safe := safeRootQdiscKinds[kind]; safe {
+		if isSafeRootQdiscKind(kind) {
 			continue
 		}
 		return &ErrUserRootQdisc{Interface: ifc, Kind: kind}

--- a/go/action_kit_commons/network/netfault/netfault_test.go
+++ b/go/action_kit_commons/network/netfault/netfault_test.go
@@ -14,23 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type fakeRunner struct {
-	calls []struct {
-		args []string
-		cmds []string
-	}
-}
-
-func (f *fakeRunner) run(_ context.Context, args []string, cmds []string) (string, error) {
-	f.calls = append(f.calls, struct {
-		args []string
-		cmds []string
-	}{args: args, cmds: cmds})
-	return "", nil
-}
-
-func (f *fakeRunner) id() string { return "testns" }
-
 func TestApply_Order_IptablesBeforeTcWhenTcpPshOnly(t *testing.T) {
 	// Disable ipv6 for the test to avoid ip6tables invocation
 	ipv6Supported = func() bool { return false }
@@ -45,7 +28,7 @@ func TestApply_Order_IptablesBeforeTcWhenTcpPshOnly(t *testing.T) {
 	}
 
 	r := &fakeRunner{}
-	err := Apply(context.Background(), r, opts)
+	_, err := Apply(context.Background(), r, opts)
 	assert.NoError(t, err)
 
 	iptablesIdx := -1
@@ -54,7 +37,7 @@ func TestApply_Order_IptablesBeforeTcWhenTcpPshOnly(t *testing.T) {
 		if len(c.args) > 0 && c.args[0] == "iptables-restore" {
 			iptablesIdx = i
 		}
-		if len(c.args) > 0 && c.args[0] == "tc" && len(c.cmds) > 0 && strings.HasPrefix(c.cmds[0], "qdisc add") {
+		if len(c.args) > 0 && c.args[0] == "tc" && len(c.cmds) > 0 && strings.HasPrefix(c.cmds[0], "qdisc replace") {
 			tcBatchIdx = i
 		}
 	}
@@ -64,6 +47,92 @@ func TestApply_Order_IptablesBeforeTcWhenTcpPshOnly(t *testing.T) {
 	}
 	if !(iptablesIdx < tcBatchIdx) {
 		t.Fatalf("expected iptables-restore to run before tc batch: iptablesIdx=%d, tcBatchIdx=%d", iptablesIdx, tcBatchIdx)
+	}
+}
+
+func TestApply_ReturnsPreflightWarnings(t *testing.T) {
+	ipv6Supported = func() bool { return false }
+	defer func() { ipv6Supported = defaultIpv6Supported }()
+
+	tests := []struct {
+		name         string
+		interfaces   []string
+		tcOutput     string
+		wantWarnings int
+		wantSubstr   string
+	}{
+		{
+			name:         "kernel default (mq) — no warning",
+			interfaces:   []string{"eth0"},
+			tcOutput:     `qdisc mq 8002: dev eth0 root`,
+			wantWarnings: 0,
+		},
+		{
+			name:         "user-installed (htb) — warning",
+			interfaces:   []string{"eth0"},
+			tcOutput:     `qdisc htb 1: dev eth0 root refcnt 2 r2q 10 default 0x30`,
+			wantWarnings: 1,
+			wantSubstr:   `"htb"`,
+		},
+		{
+			name:       "two interfaces, one user-installed",
+			interfaces: []string{"eth0", "eth1"},
+			tcOutput: `qdisc mq 0: dev eth0 root
+qdisc cake 8001: dev eth1 root refcnt 2 bandwidth 1Gbit`,
+			wantWarnings: 1,
+			wantSubstr:   `"cake"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := &DelayOpts{
+				Filter:     Filter{Include: []network.NetWithPortRange{mustParseNetWithPortRange("0.0.0.0/0", "*")}},
+				Delay:      100 * time.Millisecond,
+				Interfaces: tt.interfaces,
+			}
+
+			// Unique netNsId per subtest so activeNetfault state does not leak.
+			r := &fakeRunner{netNsId: tt.name, stdout: tt.tcOutput}
+			warnings, err := Apply(context.Background(), r, opts)
+			assert.NoError(t, err)
+			assert.Len(t, warnings, tt.wantWarnings)
+			if tt.wantWarnings > 0 && tt.wantSubstr != "" {
+				assert.Contains(t, warnings[0], tt.wantSubstr)
+			}
+		})
+	}
+}
+
+// TestOptsProviderMatrix locks down which subsystem providers each Opts type
+// implements. Generated commands flow through type assertions in
+// generateAndRunCommands, so accidentally adding tcCommands to BlackholeOpts
+// (or any similar mistake) would silently start hitting a different code
+// path without any other test failing.
+func TestOptsProviderMatrix(t *testing.T) {
+	cases := []struct {
+		name        string
+		opts        Opts
+		hasIp       bool
+		hasTc       bool
+		hasIptables bool
+	}{
+		{"BlackholeOpts", &BlackholeOpts{}, true, false, false},
+		{"DelayOpts", &DelayOpts{}, false, true, true},
+		{"PackageLossOpts", &PackageLossOpts{}, false, true, false},
+		{"CorruptPackagesOpts", &CorruptPackagesOpts{}, false, true, false},
+		{"LimitBandwidthOpts", &LimitBandwidthOpts{}, false, true, false},
+		{"TcpResetOpts", &TcpResetOpts{}, false, false, true},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, isIp := tt.opts.(ipCommandProvider)
+			_, isTc := tt.opts.(tcCommandProvider)
+			_, isIptables := tt.opts.(iptablesScriptProvider)
+			assert.Equal(t, tt.hasIp, isIp, "ipCommandProvider")
+			assert.Equal(t, tt.hasTc, isTc, "tcCommandProvider")
+			assert.Equal(t, tt.hasIptables, isIptables, "iptablesScriptProvider")
+		})
 	}
 }
 

--- a/go/action_kit_commons/network/netfault/netfault_test.go
+++ b/go/action_kit_commons/network/netfault/netfault_test.go
@@ -28,7 +28,7 @@ func TestApply_Order_IptablesBeforeTcWhenTcpPshOnly(t *testing.T) {
 	}
 
 	r := &fakeRunner{}
-	_, err := Apply(context.Background(), r, opts)
+	err := Apply(context.Background(), r, opts)
 	assert.NoError(t, err)
 
 	iptablesIdx := -1
@@ -47,60 +47,6 @@ func TestApply_Order_IptablesBeforeTcWhenTcpPshOnly(t *testing.T) {
 	}
 	if !(iptablesIdx < tcBatchIdx) {
 		t.Fatalf("expected iptables-restore to run before tc batch: iptablesIdx=%d, tcBatchIdx=%d", iptablesIdx, tcBatchIdx)
-	}
-}
-
-func TestApply_ReturnsPreflightWarnings(t *testing.T) {
-	ipv6Supported = func() bool { return false }
-	defer func() { ipv6Supported = defaultIpv6Supported }()
-
-	tests := []struct {
-		name         string
-		interfaces   []string
-		tcOutput     string
-		wantWarnings int
-		wantSubstr   string
-	}{
-		{
-			name:         "kernel default (mq) — no warning",
-			interfaces:   []string{"eth0"},
-			tcOutput:     `qdisc mq 8002: dev eth0 root`,
-			wantWarnings: 0,
-		},
-		{
-			name:         "user-installed (htb) — warning",
-			interfaces:   []string{"eth0"},
-			tcOutput:     `qdisc htb 1: dev eth0 root refcnt 2 r2q 10 default 0x30`,
-			wantWarnings: 1,
-			wantSubstr:   `"htb"`,
-		},
-		{
-			name:       "two interfaces, one user-installed",
-			interfaces: []string{"eth0", "eth1"},
-			tcOutput: `qdisc mq 0: dev eth0 root
-qdisc cake 8001: dev eth1 root refcnt 2 bandwidth 1Gbit`,
-			wantWarnings: 1,
-			wantSubstr:   `"cake"`,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			opts := &DelayOpts{
-				Filter:     Filter{Include: []network.NetWithPortRange{mustParseNetWithPortRange("0.0.0.0/0", "*")}},
-				Delay:      100 * time.Millisecond,
-				Interfaces: tt.interfaces,
-			}
-
-			// Unique netNsId per subtest so activeNetfault state does not leak.
-			r := &fakeRunner{netNsId: tt.name, stdout: tt.tcOutput}
-			warnings, err := Apply(context.Background(), r, opts)
-			assert.NoError(t, err)
-			assert.Len(t, warnings, tt.wantWarnings)
-			if tt.wantWarnings > 0 && tt.wantSubstr != "" {
-				assert.Contains(t, warnings[0], tt.wantSubstr)
-			}
-		})
 	}
 }
 

--- a/go/action_kit_commons/network/netfault/packageCorruption.go
+++ b/go/action_kit_commons/network/netfault/packageCorruption.go
@@ -45,8 +45,8 @@ func (o *CorruptPackagesOpts) doesConflictWith(opts Opts) bool {
 	return false
 }
 
-func (o *CorruptPackagesOpts) ipCommands(_ family, _ mode) ([]string, error) {
-	return nil, nil
+func (o *CorruptPackagesOpts) tcRootQdiscInterfaces() []string {
+	return o.Interfaces
 }
 
 func (o *CorruptPackagesOpts) tcCommands(mode mode) ([]string, error) {
@@ -54,7 +54,7 @@ func (o *CorruptPackagesOpts) tcCommands(mode mode) ([]string, error) {
 
 	filter := optimizeFilter(o.Filter)
 	for _, ifc := range o.Interfaces {
-		cmds = append(cmds, fmt.Sprintf("qdisc %s dev %s root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0", mode, ifc))
+		cmds = append(cmds, fmt.Sprintf("qdisc %s dev %s root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0", rootQdiscVerb(mode), ifc))
 		cmds = append(cmds, fmt.Sprintf("qdisc %s dev %s parent %s handle 30: netem corrupt %d%%", mode, ifc, handleInclude, o.Corruption))
 
 		filterCmds, err := tcCommandsForFilter(mode, filter, ifc)

--- a/go/action_kit_commons/network/netfault/packageCorruption_test.go
+++ b/go/action_kit_commons/network/netfault/packageCorruption_test.go
@@ -38,7 +38,7 @@ func TestCorruptPackagesOpts_TcCommands(t *testing.T) {
 				Corruption: 90,
 				Interfaces: []string{"eth0"},
 			},
-			wantAdd: []byte(`qdisc add dev eth0 root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+			wantAdd: []byte(`qdisc replace dev eth0 root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
 qdisc add dev eth0 parent 1:3 handle 30: netem corrupt 90%
 filter add dev eth0 protocol ip parent 1: prio 1 u32 match ip src 192.168.2.1/32 match ip sport 80 0xffff flowid 1:1
 filter add dev eth0 protocol ip parent 1: prio 2 u32 match ip dst 192.168.2.1/32 match ip dport 80 0xffff flowid 1:1

--- a/go/action_kit_commons/network/netfault/packageLoss.go
+++ b/go/action_kit_commons/network/netfault/packageLoss.go
@@ -44,8 +44,8 @@ func (o *PackageLossOpts) doesConflictWith(opts Opts) bool {
 
 	return false
 }
-func (o *PackageLossOpts) ipCommands(_ family, _ mode) ([]string, error) {
-	return nil, nil
+func (o *PackageLossOpts) tcRootQdiscInterfaces() []string {
+	return o.Interfaces
 }
 
 func (o *PackageLossOpts) tcCommands(mode mode) ([]string, error) {
@@ -53,7 +53,7 @@ func (o *PackageLossOpts) tcCommands(mode mode) ([]string, error) {
 
 	filter := optimizeFilter(o.Filter)
 	for _, ifc := range o.Interfaces {
-		cmds = append(cmds, fmt.Sprintf("qdisc %s dev %s root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0", mode, ifc))
+		cmds = append(cmds, fmt.Sprintf("qdisc %s dev %s root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0", rootQdiscVerb(mode), ifc))
 		cmds = append(cmds, fmt.Sprintf("qdisc %s dev %s parent %s handle 30: netem loss random %d%%", mode, ifc, handleInclude, o.Loss))
 
 		filterCmds, err := tcCommandsForFilter(mode, filter, ifc)

--- a/go/action_kit_commons/network/netfault/packageLoss_test.go
+++ b/go/action_kit_commons/network/netfault/packageLoss_test.go
@@ -38,7 +38,7 @@ func TestPackageLossOpts_TcCommands(t *testing.T) {
 				Loss:       90,
 				Interfaces: []string{"eth0"},
 			},
-			wantAdd: []byte(`qdisc add dev eth0 root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+			wantAdd: []byte(`qdisc replace dev eth0 root handle 1: prio priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
 qdisc add dev eth0 parent 1:3 handle 30: netem loss random 90%
 filter add dev eth0 protocol ip parent 1: prio 1 u32 match ip src 192.168.2.1/32 match ip sport 80 0xffff flowid 1:1
 filter add dev eth0 protocol ip parent 1: prio 2 u32 match ip dst 192.168.2.1/32 match ip dport 80 0xffff flowid 1:1

--- a/go/action_kit_commons/network/netfault/preflight.go
+++ b/go/action_kit_commons/network/netfault/preflight.go
@@ -8,47 +8,17 @@ import (
 	"context"
 	"fmt"
 	"strings"
-
-	"github.com/rs/zerolog/log"
 )
 
 // Kinds the Linux kernel re-attaches automatically after `tc qdisc del root`.
 // Anything else was user-installed (or installed by a CNI bandwidth plugin)
-// and will be replaced by the kernel default on revert.
+// and cannot be restored after the attack, so the preflight refuses it.
 var safeRootQdiscKinds = map[string]struct{}{
 	"mq":         {},
 	"noqueue":    {},
 	"pfifo_fast": {},
 	"fq_codel":   {},
 	"fq":         {},
-}
-
-func preflightWarnings(ctx context.Context, runner CommandRunner, interfaces []string) []string {
-	if len(interfaces) == 0 {
-		return nil
-	}
-
-	kinds, err := inspectRootQdiscs(ctx, runner)
-	if err != nil {
-		log.Warn().Err(err).Msg("failed to inspect root qdiscs; skipping preflight check")
-		return nil
-	}
-
-	var warnings []string
-	for _, ifc := range interfaces {
-		kind := kinds[ifc]
-		if kind == "" {
-			continue
-		}
-		if _, safe := safeRootQdiscKinds[kind]; safe {
-			continue
-		}
-		warnings = append(warnings, fmt.Sprintf(
-			"Pre-existing qdisc %q on interface %q will be replaced during the attack. After the attack ends the kernel will restore its default qdisc, which may differ from the original configuration.",
-			kind, ifc,
-		))
-	}
-	return warnings
 }
 
 // inspectRootQdiscs returns a map from interface name to root qdisc kind for

--- a/go/action_kit_commons/network/netfault/preflight.go
+++ b/go/action_kit_commons/network/netfault/preflight.go
@@ -21,6 +21,36 @@ var safeRootQdiscKinds = map[string]struct{}{
 	"fq":         {},
 }
 
+// strictSafeRootQdiscKinds is the opt-in fallback safe-set: only an interface
+// with no real root qdisc (`noqueue`, e.g. a fresh veth) is considered safe to
+// replace. Every other pre-existing root — including the kernel default `mq`
+// on managed-cloud nodes — is refused at preflight. Enabled via
+// SetStrictRootQdisc for operators who don't want network attacks to replace
+// any kernel-managed root qdisc.
+var strictSafeRootQdiscKinds = map[string]struct{}{
+	"noqueue": {},
+}
+
+// strictRootQdisc selects strictSafeRootQdiscKinds when true (default false).
+var strictRootQdisc bool
+
+// SetStrictRootQdisc toggles the strict preflight safe-set. When enabled, the
+// preflight refuses any interface whose root qdisc is not `noqueue`. Off by
+// default; intended as a per-deployment opt-out for customers who prefer the
+// attack to never touch a pre-existing root qdisc.
+func SetStrictRootQdisc(enabled bool) { strictRootQdisc = enabled }
+
+// isSafeRootQdiscKind reports whether a pre-existing root qdisc of the given
+// kind may be replaced by the attack under the active configuration.
+func isSafeRootQdiscKind(kind string) bool {
+	safe := safeRootQdiscKinds
+	if strictRootQdisc {
+		safe = strictSafeRootQdiscKinds
+	}
+	_, ok := safe[kind]
+	return ok
+}
+
 // inspectRootQdiscs returns a map from interface name to root qdisc kind for
 // every interface in the runner's network namespace. Uses the human-readable
 // `tc qdisc show` output (not -json) so the check works on older iproute2.

--- a/go/action_kit_commons/network/netfault/preflight.go
+++ b/go/action_kit_commons/network/netfault/preflight.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Steadybit GmbH
+//go:build !windows
+
+package netfault
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+)
+
+// Kinds the Linux kernel re-attaches automatically after `tc qdisc del root`.
+// Anything else was user-installed (or installed by a CNI bandwidth plugin)
+// and will be replaced by the kernel default on revert.
+var safeRootQdiscKinds = map[string]struct{}{
+	"mq":         {},
+	"noqueue":    {},
+	"pfifo_fast": {},
+	"fq_codel":   {},
+	"fq":         {},
+}
+
+func preflightWarnings(ctx context.Context, runner CommandRunner, interfaces []string) []string {
+	if len(interfaces) == 0 {
+		return nil
+	}
+
+	kinds, err := inspectRootQdiscs(ctx, runner)
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to inspect root qdiscs; skipping preflight check")
+		return nil
+	}
+
+	var warnings []string
+	for _, ifc := range interfaces {
+		kind := kinds[ifc]
+		if kind == "" {
+			continue
+		}
+		if _, safe := safeRootQdiscKinds[kind]; safe {
+			continue
+		}
+		warnings = append(warnings, fmt.Sprintf(
+			"Pre-existing qdisc %q on interface %q will be replaced during the attack. After the attack ends the kernel will restore its default qdisc, which may differ from the original configuration.",
+			kind, ifc,
+		))
+	}
+	return warnings
+}
+
+// inspectRootQdiscs returns a map from interface name to root qdisc kind for
+// every interface in the runner's network namespace. Uses the human-readable
+// `tc qdisc show` output (not -json) so the check works on older iproute2.
+func inspectRootQdiscs(ctx context.Context, runner CommandRunner) (map[string]string, error) {
+	out, err := runner.run(ctx, []string{"tc", "qdisc", "show"}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("tc qdisc show failed: %w", err)
+	}
+	return parseRootQdiscKinds(out), nil
+}
+
+// parseRootQdiscKinds returns a map from interface name to root qdisc kind.
+// Root qdiscs are formatted as `qdisc <kind> <handle> dev <ifc> root ...`;
+// `ingress`/`clsact` lines use `parent` instead of `root` and are skipped.
+func parseRootQdiscKinds(out string) map[string]string {
+	kinds := make(map[string]string)
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) < 6 || fields[0] != "qdisc" || fields[3] != "dev" || fields[5] != "root" {
+			continue
+		}
+		kinds[fields[4]] = fields[1]
+	}
+	return kinds
+}

--- a/go/action_kit_commons/network/netfault/preflight_test.go
+++ b/go/action_kit_commons/network/netfault/preflight_test.go
@@ -227,3 +227,35 @@ func TestPreflightCheck_SkippedWhenAttackActive(t *testing.T) {
 	assert.NoError(t, err, "preflight must defer to conflict detection when an attack is already active")
 	assert.Empty(t, r.calls, "preflight should not even inspect when an attack is already active")
 }
+
+// With SetStrictRootQdisc(true) the only safe root is `noqueue`; every other
+// pre-existing root — including the kernel default `mq` — is refused.
+func TestPreflightCheck_StrictMode(t *testing.T) {
+	SetStrictRootQdisc(true)
+	defer SetStrictRootQdisc(false)
+
+	cases := []struct {
+		name     string
+		tcOutput string
+		wantErr  bool
+		wantKind string
+	}{
+		{name: "noqueue allowed", tcOutput: `qdisc noqueue 0: dev eth0 root refcnt 2`, wantErr: false},
+		{name: "mq refused", tcOutput: `qdisc mq 8002: dev eth0 root`, wantErr: true, wantKind: "mq"},
+		{name: "fq_codel refused", tcOutput: `qdisc fq_codel 0: dev eth0 root`, wantErr: true, wantKind: "fq_codel"},
+		{name: "htb refused", tcOutput: `qdisc htb 1: dev eth0 root`, wantErr: true, wantKind: "htb"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &fakeRunner{netNsId: "strict-" + tc.name, stdout: tc.tcOutput}
+			err := PreflightCheck(context.Background(), r, &DelayOpts{Interfaces: []string{"eth0"}})
+			if !tc.wantErr {
+				assert.NoError(t, err)
+				return
+			}
+			var e *ErrUserRootQdisc
+			require.ErrorAs(t, err, &e)
+			assert.Equal(t, tc.wantKind, e.Kind)
+		})
+	}
+}

--- a/go/action_kit_commons/network/netfault/preflight_test.go
+++ b/go/action_kit_commons/network/netfault/preflight_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseRootQdiscKinds(t *testing.T) {
@@ -125,93 +126,104 @@ func (f *fakeRunner) id() string {
 	return f.netNsId
 }
 
-func TestPreflightWarnings(t *testing.T) {
+func TestPreflightCheck(t *testing.T) {
 	tests := []struct {
 		name       string
 		interfaces []string
 		tcOutput   string
 		runErr     error
-		wantCount  int
-		wantSubstr string
+		wantErr    bool
+		wantIfc    string
+		wantKind   string
 	}{
 		{
-			name:       "no interfaces",
+			name:       "no interfaces — ok",
 			interfaces: nil,
-			wantCount:  0,
 		},
 		{
-			name:       "mq (GKE COS) — no warning",
+			name:       "mq (GKE COS) — ok",
 			interfaces: []string{"eth0"},
 			tcOutput:   `qdisc mq 8002: dev eth0 root`,
-			wantCount:  0,
 		},
 		{
-			name:       "fq_codel — no warning",
-			interfaces: []string{"eth0"},
-			tcOutput:   `qdisc fq_codel 0: dev eth0 root refcnt 2 limit 10240p flows 1024`,
-			wantCount:  0,
-		},
-		{
-			name:       "pfifo_fast — no warning",
-			interfaces: []string{"eth0"},
-			tcOutput:   `qdisc pfifo_fast 0: dev eth0 root refcnt 2 bands 3`,
-			wantCount:  0,
-		},
-		{
-			name:       "noqueue — no warning",
+			name:       "noqueue — ok",
 			interfaces: []string{"veth0"},
 			tcOutput:   `qdisc noqueue 0: dev veth0 root refcnt 2`,
-			wantCount:  0,
 		},
 		{
-			name:       "fq — no warning",
+			name:       "fq_codel — ok",
 			interfaces: []string{"eth0"},
-			tcOutput:   `qdisc fq 8001: dev eth0 root refcnt 2 limit 10000p`,
-			wantCount:  0,
+			tcOutput:   `qdisc fq_codel 0: dev eth0 root refcnt 2 limit 10240p`,
 		},
 		{
-			name:       "htb — warning",
-			interfaces: []string{"eth0"},
-			tcOutput:   `qdisc htb 1: dev eth0 root refcnt 2 r2q 10 default 0x30`,
-			wantCount:  1,
-			wantSubstr: `"htb"`,
-		},
-		{
-			name:       "cake — warning",
-			interfaces: []string{"eth0"},
-			tcOutput:   `qdisc cake 8001: dev eth0 root refcnt 2 bandwidth 1Gbit`,
-			wantCount:  1,
-			wantSubstr: `"cake"`,
-		},
-		{
-			name:       "multi-interface: only the user-installed one warns",
-			interfaces: []string{"eth0", "eth1"},
-			tcOutput: `qdisc mq 8002: dev eth0 root
-qdisc htb 1: dev eth1 root`,
-			wantCount:  1,
-			wantSubstr: `"eth1"`,
-		},
-		{
-			name:       "tc failure — no warning, error swallowed",
-			interfaces: []string{"eth0"},
-			runErr:     errors.New("tc not found"),
-			wantCount:  0,
-		},
-		{
-			name:       "interface has no root qdisc — no warning",
+			name:       "interface has no root qdisc — ok",
 			interfaces: []string{"eth0"},
 			tcOutput:   "",
-			wantCount:  0,
+		},
+		{
+			name:       "tc failure — skipped, no error",
+			interfaces: []string{"eth0"},
+			runErr:     errors.New("tc not found"),
+		},
+		{
+			name:       "user-installed htb — refused",
+			interfaces: []string{"eth0"},
+			tcOutput:   `qdisc htb 1: dev eth0 root refcnt 2 default 0x30`,
+			wantErr:    true,
+			wantIfc:    "eth0",
+			wantKind:   "htb",
+		},
+		{
+			name:       "user-installed cake — refused",
+			interfaces: []string{"eth0"},
+			tcOutput:   `qdisc cake 8001: dev eth0 root bandwidth 1Gbit`,
+			wantErr:    true,
+			wantIfc:    "eth0",
+			wantKind:   "cake",
+		},
+		{
+			name:       "multi-interface: only the user-installed one is refused",
+			interfaces: []string{"eth0", "eth1"},
+			tcOutput:   "qdisc mq 8002: dev eth0 root\nqdisc htb 1: dev eth1 root",
+			wantErr:    true,
+			wantIfc:    "eth1",
+			wantKind:   "htb",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := &fakeRunner{stdout: tt.tcOutput, err: tt.runErr}
-			got := preflightWarnings(context.Background(), r, tt.interfaces)
-			assert.Len(t, got, tt.wantCount)
-			if tt.wantCount > 0 && tt.wantSubstr != "" {
-				assert.Contains(t, got[0], tt.wantSubstr)
+			// Unique netNsId per subtest so activeNetfault state from other
+			// tests does not leak in and short-circuit the check.
+			r := &fakeRunner{netNsId: tt.name, stdout: tt.tcOutput, err: tt.runErr}
+			err := PreflightCheck(context.Background(), r, &DelayOpts{Interfaces: tt.interfaces})
+			if !tt.wantErr {
+				assert.NoError(t, err)
+				return
 			}
+			var e *ErrUserRootQdisc
+			require.ErrorAs(t, err, &e)
+			assert.Equal(t, tt.wantIfc, e.Interface)
+			assert.Equal(t, tt.wantKind, e.Kind)
 		})
 	}
+}
+
+// A root qdisc belonging to an already-running steadybit attack on the same
+// netns must not trip the preflight — the apply-time conflict detection owns
+// that decision. We simulate an active attack by seeding activeNetfault.
+func TestPreflightCheck_SkippedWhenAttackActive(t *testing.T) {
+	const ns = "ns-active"
+	activeNetfaultLock.Lock()
+	activeNetfault[ns] = []Opts{&DelayOpts{Interfaces: []string{"docker0"}}}
+	activeNetfaultLock.Unlock()
+	defer func() {
+		activeNetfaultLock.Lock()
+		delete(activeNetfault, ns)
+		activeNetfaultLock.Unlock()
+	}()
+
+	r := &fakeRunner{netNsId: ns, stdout: `qdisc htb 1: dev eth0 root`}
+	err := PreflightCheck(context.Background(), r, &DelayOpts{Interfaces: []string{"eth0"}})
+	assert.NoError(t, err, "preflight must defer to conflict detection when an attack is already active")
+	assert.Empty(t, r.calls, "preflight should not even inspect when an attack is already active")
 }

--- a/go/action_kit_commons/network/netfault/preflight_test.go
+++ b/go/action_kit_commons/network/netfault/preflight_test.go
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Steadybit GmbH
+//go:build !windows
+
+package netfault
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseRootQdiscKinds(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want map[string]string
+	}{
+		{
+			name: "empty output",
+			out:  "",
+			want: map[string]string{},
+		},
+		{
+			name: "GKE COS multi-queue eth0",
+			out: `qdisc mq 8002: dev eth0 root
+qdisc fq_codel 0: dev eth0 parent 8002:4 limit 10240p flows 1024
+qdisc fq_codel 0: dev eth0 parent 8002:3 limit 10240p flows 1024
+qdisc fq_codel 0: dev eth0 parent 8002:2 limit 10240p flows 1024
+qdisc fq_codel 0: dev eth0 parent 8002:1 limit 10240p flows 1024`,
+			want: map[string]string{"eth0": "mq"},
+		},
+		{
+			name: "modern single-queue with fq_codel default",
+			out:  `qdisc fq_codel 0: dev eth0 root refcnt 2 limit 10240p flows 1024`,
+			want: map[string]string{"eth0": "fq_codel"},
+		},
+		{
+			name: "old single-queue with pfifo_fast",
+			out:  `qdisc pfifo_fast 0: dev eth0 root refcnt 2 bands 3 priomap  1 2 2 2 1 2 0 0 1 1 1 1 1 1 1 1`,
+			want: map[string]string{"eth0": "pfifo_fast"},
+		},
+		{
+			name: "veth with noqueue",
+			out:  `qdisc noqueue 0: dev veth0 root refcnt 2`,
+			want: map[string]string{"veth0": "noqueue"},
+		},
+		{
+			name: "user-installed htb",
+			out:  `qdisc htb 1: dev eth0 root refcnt 2 r2q 10 default 0x30 direct_packets_stat 0 direct_qlen 1000`,
+			want: map[string]string{"eth0": "htb"},
+		},
+		{
+			name: "user-installed cake",
+			out:  `qdisc cake 8001: dev eth0 root refcnt 2 bandwidth 1Gbit diffserv3 triple-isolate nonat nowash no-ack-filter split-gso rtt 100ms raw overhead 0`,
+			want: map[string]string{"eth0": "cake"},
+		},
+		{
+			name: "fq default (BBR)",
+			out:  `qdisc fq 8001: dev eth0 root refcnt 2 limit 10000p flow_limit 100p buckets 1024`,
+			want: map[string]string{"eth0": "fq"},
+		},
+		{
+			name: "ingress only — not root",
+			out:  `qdisc clsact ffff: dev eth0 parent ffff:fff1`,
+			want: map[string]string{},
+		},
+		{
+			name: "root + ingress companion",
+			out: `qdisc fq_codel 0: dev eth0 root refcnt 2 limit 10240p flows 1024
+qdisc clsact ffff: dev eth0 parent ffff:fff1`,
+			want: map[string]string{"eth0": "fq_codel"},
+		},
+		{
+			name: "multiple interfaces, mixed kinds",
+			out: `qdisc mq 8002: dev eth0 root
+qdisc htb 1: dev eth1 root refcnt 2 r2q 10 default 0x30
+qdisc noqueue 0: dev lo root refcnt 2`,
+			want: map[string]string{"eth0": "mq", "eth1": "htb", "lo": "noqueue"},
+		},
+		{
+			name: "leading whitespace tolerated",
+			out:  "   qdisc mq 8002: dev eth0 root",
+			want: map[string]string{"eth0": "mq"},
+		},
+		{
+			name: "garbage line ignored",
+			out: `Cannot find device "eth42"
+qdisc mq 0: dev eth0 root`,
+			want: map[string]string{"eth0": "mq"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, parseRootQdiscKinds(tt.out))
+		})
+	}
+}
+
+// fakeRunner is a CommandRunner that returns canned stdout for any command,
+// optionally erroring. Used by the netfault, preflight and Apply tests.
+type fakeRunner struct {
+	netNsId string
+	stdout  string
+	err     error
+	calls   []recordedCall
+}
+
+type recordedCall struct {
+	args []string
+	cmds []string
+}
+
+func (f *fakeRunner) run(_ context.Context, args []string, cmds []string) (string, error) {
+	f.calls = append(f.calls, recordedCall{args: args, cmds: cmds})
+	return f.stdout, f.err
+}
+
+func (f *fakeRunner) id() string {
+	if f.netNsId == "" {
+		return "testns"
+	}
+	return f.netNsId
+}
+
+func TestPreflightWarnings(t *testing.T) {
+	tests := []struct {
+		name       string
+		interfaces []string
+		tcOutput   string
+		runErr     error
+		wantCount  int
+		wantSubstr string
+	}{
+		{
+			name:       "no interfaces",
+			interfaces: nil,
+			wantCount:  0,
+		},
+		{
+			name:       "mq (GKE COS) — no warning",
+			interfaces: []string{"eth0"},
+			tcOutput:   `qdisc mq 8002: dev eth0 root`,
+			wantCount:  0,
+		},
+		{
+			name:       "fq_codel — no warning",
+			interfaces: []string{"eth0"},
+			tcOutput:   `qdisc fq_codel 0: dev eth0 root refcnt 2 limit 10240p flows 1024`,
+			wantCount:  0,
+		},
+		{
+			name:       "pfifo_fast — no warning",
+			interfaces: []string{"eth0"},
+			tcOutput:   `qdisc pfifo_fast 0: dev eth0 root refcnt 2 bands 3`,
+			wantCount:  0,
+		},
+		{
+			name:       "noqueue — no warning",
+			interfaces: []string{"veth0"},
+			tcOutput:   `qdisc noqueue 0: dev veth0 root refcnt 2`,
+			wantCount:  0,
+		},
+		{
+			name:       "fq — no warning",
+			interfaces: []string{"eth0"},
+			tcOutput:   `qdisc fq 8001: dev eth0 root refcnt 2 limit 10000p`,
+			wantCount:  0,
+		},
+		{
+			name:       "htb — warning",
+			interfaces: []string{"eth0"},
+			tcOutput:   `qdisc htb 1: dev eth0 root refcnt 2 r2q 10 default 0x30`,
+			wantCount:  1,
+			wantSubstr: `"htb"`,
+		},
+		{
+			name:       "cake — warning",
+			interfaces: []string{"eth0"},
+			tcOutput:   `qdisc cake 8001: dev eth0 root refcnt 2 bandwidth 1Gbit`,
+			wantCount:  1,
+			wantSubstr: `"cake"`,
+		},
+		{
+			name:       "multi-interface: only the user-installed one warns",
+			interfaces: []string{"eth0", "eth1"},
+			tcOutput: `qdisc mq 8002: dev eth0 root
+qdisc htb 1: dev eth1 root`,
+			wantCount:  1,
+			wantSubstr: `"eth1"`,
+		},
+		{
+			name:       "tc failure — no warning, error swallowed",
+			interfaces: []string{"eth0"},
+			runErr:     errors.New("tc not found"),
+			wantCount:  0,
+		},
+		{
+			name:       "interface has no root qdisc — no warning",
+			interfaces: []string{"eth0"},
+			tcOutput:   "",
+			wantCount:  0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &fakeRunner{stdout: tt.tcOutput, err: tt.runErr}
+			got := preflightWarnings(context.Background(), r, tt.interfaces)
+			assert.Len(t, got, tt.wantCount)
+			if tt.wantCount > 0 && tt.wantSubstr != "" {
+				assert.Contains(t, got[0], tt.wantSubstr)
+			}
+		})
+	}
+}

--- a/go/action_kit_commons/network/netfault/runner_runc_test.go
+++ b/go/action_kit_commons/network/netfault/runner_runc_test.go
@@ -48,7 +48,7 @@ func Test_generateAndRunCommands_using_runc_should_serialize(t *testing.T) {
 
 			runner := NewRuncRunner(runcMock, sidecar)
 
-			_ = Apply(context.Background(), runner, &blackholeOpts)
+			_, _ = Apply(context.Background(), runner, &blackholeOpts)
 			defer func(ctx context.Context, runner CommandRunner, opts Opts) {
 				_ = Revert(ctx, runner, opts)
 			}(context.Background(), runner, &blackholeOpts)

--- a/go/action_kit_commons/network/netfault/runner_runc_test.go
+++ b/go/action_kit_commons/network/netfault/runner_runc_test.go
@@ -48,7 +48,7 @@ func Test_generateAndRunCommands_using_runc_should_serialize(t *testing.T) {
 
 			runner := NewRuncRunner(runcMock, sidecar)
 
-			_, _ = Apply(context.Background(), runner, &blackholeOpts)
+			_ = Apply(context.Background(), runner, &blackholeOpts)
 			defer func(ctx context.Context, runner CommandRunner, opts Opts) {
 				_ = Revert(ctx, runner, opts)
 			}(context.Background(), runner, &blackholeOpts)

--- a/go/action_kit_commons/network/netfault/tcp_reset.go
+++ b/go/action_kit_commons/network/netfault/tcp_reset.go
@@ -70,14 +70,6 @@ func (o *TcpResetOpts) doesConflictWith(opts Opts) bool {
 	return !reflect.DeepEqual(o.Interfaces, other.Interfaces)
 }
 
-func (o *TcpResetOpts) ipCommands(_ family, _ mode) ([]string, error) {
-	return nil, nil
-}
-
-func (o *TcpResetOpts) tcCommands(_ mode) ([]string, error) {
-	return nil, nil
-}
-
 func (o *TcpResetOpts) iptablesScripts(mode mode) (v4 []string, v6 []string, err error) {
 	if o.UseMangleChain {
 		return o.mangleMarkScripts(mode)

--- a/go/action_kit_commons/network/netfault/tcp_reset_test.go
+++ b/go/action_kit_commons/network/netfault/tcp_reset_test.go
@@ -458,26 +458,6 @@ func TestTcpResetOpts_chainName(t *testing.T) {
 		(&TcpResetOpts{}).rstFilterChainName())
 }
 
-func TestTcpResetOpts_ipAndTcCommandsReturnNil(t *testing.T) {
-	opts := &TcpResetOpts{
-		Filter: Filter{
-			Include: network.NewNetWithPortRanges(network.NetAny, network.PortRangeAny),
-		},
-	}
-
-	ipCmds, err := opts.ipCommands(familyV4, modeAdd)
-	require.NoError(t, err)
-	assert.Nil(t, ipCmds)
-
-	ipCmds, err = opts.ipCommands(familyV6, modeAdd)
-	require.NoError(t, err)
-	assert.Nil(t, ipCmds)
-
-	tcCmds, err := opts.tcCommands(modeAdd)
-	require.NoError(t, err)
-	assert.Nil(t, tcCmds)
-}
-
 func TestTcpResetOpts_doesConflictWith(t *testing.T) {
 	filter := Filter{Include: network.NewNetWithPortRanges(network.NetAny, network.PortRangeAny)}
 

--- a/go/action_kit_commons/network/netfault/types.go
+++ b/go/action_kit_commons/network/netfault/types.go
@@ -20,9 +20,10 @@ type Filter struct {
 	Exclude []network.NetWithPortRange
 }
 
+// Opts is the common contract every netfault attack implements. Subsystem-
+// specific behavior is opt-in via the *Provider interfaces below — an attack
+// only implements the providers for the subsystems it actually uses.
 type Opts interface {
-	ipCommands(family family, mode mode) ([]string, error)
-	tcCommands(mode mode) ([]string, error)
 	String() string
 	toExecutionContext() ExecutionContext
 	doesConflictWith(opts Opts) bool
@@ -34,6 +35,22 @@ type ExecutionContext struct {
 	TargetExecutionId     string
 }
 
+// tcCommandProvider is implemented by attacks that use the tc subsystem.
+// tcRootQdiscInterfaces names the interfaces whose root qdisc the attack
+// installs; the preflight uses it to detect pre-existing user qdiscs.
+type tcCommandProvider interface {
+	tcCommands(mode mode) ([]string, error)
+	tcRootQdiscInterfaces() []string
+}
+
+// ipCommandProvider is implemented by attacks that install ip rules (policy
+// routing).
+type ipCommandProvider interface {
+	ipCommands(family family, mode mode) ([]string, error)
+}
+
+// iptablesScriptProvider is implemented by attacks that install iptables /
+// ip6tables rules via iptables-restore.
 type iptablesScriptProvider interface {
 	iptablesScripts(mode mode) (v4 []string, v6 []string, err error)
 }

--- a/go/action_kit_commons/network/netfault/utils.go
+++ b/go/action_kit_commons/network/netfault/utils.go
@@ -22,6 +22,15 @@ func reorderForMode(cmds []string, mode mode) {
 	}
 }
 
+// rootQdiscVerb returns `replace` for apply (so we don't fail when the kernel
+// has already attached a root qdisc) and `del` for revert.
+func rootQdiscVerb(m mode) string {
+	if m == modeAdd {
+		return "replace"
+	}
+	return string(m)
+}
+
 func toReader(strs []string) io.Reader {
 	return strings.NewReader(fmt.Sprintf("%s\n", strings.Join(strs, "\n")))
 }


### PR DESCRIPTION
## Summary

Network attacks using tc (delay, loss, corruption, bandwidth) currently fail on hosts where the kernel has already attached a root qdisc to the target interface — most notably `mq` on GKE COS / EKS / AKS / RHCOS, where `tc qdisc add dev eth0 root handle 1: prio ...` returns `NLM_F_REPLACE needed to override`.

This PR makes two changes:

1. **`add` → `replace` for the root qdisc** on apply, which works whether or not a root qdisc is already attached. On revert we still `qdisc del root` and the kernel auto-restores the device's default (`mq` on multi-queue devices, `noqueue` on veth, otherwise `net.core.default_qdisc`, typically `fq_codel`). This fully covers the common cloud-node setups — including the customer's GKE `mq` — where pre-attack and post-attack state are identical.

2. **`PreflightCheck` (Prepare-time) for user-installed root qdiscs.** A kernel default (`mq`, `noqueue`, `pfifo_fast`, `fq_codel`, `fq`) is accepted and auto-restored. A user/CNI-installed root qdisc (`htb`, `cake`, …) **cannot** be faithfully restored afterwards — `tc` has no reliable save/restore for an arbitrary qdisc tree — so rather than silently replacing it, the attack **fails fast in Prepare** with an `*ErrUserRootQdisc` and never touches the host. The check is skipped when a steadybit attack is already active on the netns (concurrent-attack rejection stays with the existing apply-time conflict detection).

Related ticket: https://steadybitgmbh.kanbanize.com/ctrl_board/9/cards/18920/details/

## API

- `Apply` signature is **unchanged** (`error`) vs the last release — not a breaking change.
- Adds exported `PreflightCheck(ctx, runner, opts) error` and `ErrUserRootQdisc`. Callers invoke `PreflightCheck` from their action's Prepare step.
- Suggested release: **v1.8.0** (additive).

## Why fail-fast instead of replace-and-warn (prior-art survey)

We surveyed how other tools handle a pre-existing/custom root qdisc:

| Tool | On a custom/non-default root qdisc |
|---|---|
| Chaos Mesh | `tc qdisc del root` unconditionally, then rebuild — clobbers silently, no restore |
| LitmusChaos | `tc qdisc replace root` — clobbers silently, no restore |
| ChaosBlade | fails `File exists`; `--force` → `del root` first (no restore) |
| Pumba / AWS FIS | `tc qdisc add root` — **fail** on a pre-existing root (the bug this PR fixes) |
| **Krkn `network_chaos_ng`** (Red Hat) | **inspects `tc qdisc show`; refuses by default**, `force: true` to override — no restore |
| tcconfig | detects `File exists`; refuses by default, explicit `--add`/`--overwrite`/`--change` |

Findings: **no tool snapshots+restores an arbitrary qdisc tree**, and **none attaches netem beneath an existing `mq`** for selective faults (you must own a classful root for `tc filter`, and `mq` isn't classful). The field is "clobber silently", "clobber on --force", or "detect + refuse". This PR is in the most conservative camp, with direct precedent in Krkn `network_chaos_ng` (detect-and-refuse) and tcconfig.

Sources: [Chaos Mesh `tc_server.go`](https://github.com/chaos-mesh/chaos-mesh/blob/master/pkg/chaosdaemon/tc_server.go) · [litmus-go `netem.go`](https://github.com/litmuschaos/litmus-go/blob/master/chaoslib/litmus/network-chaos/helper/netem.go) · [ChaosBlade `network_tc.go`](https://github.com/chaosblade-io/chaosblade-exec-os/blob/master/exec/network/tc/network_tc.go) · [Krkn `utils_network_chaos.py`](https://github.com/krkn-chaos/krkn/blob/main/krkn/scenario_plugins/network_chaos_ng/modules/utils_network_chaos.py) · [tcconfig `traffic_control.py`](https://github.com/thombashi/tcconfig/blob/master/tcconfig/traffic_control.py) · [AWS FIS SSM docs](https://docs.aws.amazon.com/fis/latest/userguide/actions-ssm-agent.html)

## Test plan

- [x] Unit tests: `delay`/`loss`/`corruption`/`bandwidth` command fixtures (`qdisc replace ... root`)
- [x] `preflight_test.go`: `parseRootQdiscKinds` across mq+children (GKE), fq_codel, pfifo_fast, noqueue, htb, cake, fq, ingress-only, garbage lines
- [x] `TestPreflightCheck`: mq/noqueue/fq_codel accepted; htb/cake refused with `*ErrUserRootQdisc`; multi-interface; tc-failure skipped; and skipped when an attack is already active on the netns
- [x] `go test ./...` on action_kit_commons: 94 netfault tests pass
- [x] Downstream e2e (extension-host minikube): kernel-default interface runs; htb interface refused at Prepare and **left untouched** — verified against this branch's pseudo-version

## Notes

- Do **not** merge before the extension-host / extension-container companion PRs are ready.
- Please **do not enable auto-merge**.
