### PR TITLE
style: gofmt tcp_reset.go and tcp_reset_test.go

### DIFF
--- a/go/action_kit_commons/network/netfault/tcp_reset.go
+++ b/go/action_kit_commons/network/netfault/tcp_reset.go
@@ -17,8 +17,8 @@ const mangleMarkValue = "0x5B"
 type TcpResetOpts struct {
 	Filter
 	ExecutionContext
-	Interfaces    []string
-	Prepend       bool
+	Interfaces     []string
+	Prepend        bool
 	UseMangleChain bool
 }
 

--- a/go/action_kit_commons/network/netfault/tcp_reset_test.go
+++ b/go/action_kit_commons/network/netfault/tcp_reset_test.go
@@ -281,7 +281,7 @@ func TestTcpResetOpts_iptablesScripts(t *testing.T) {
 					Include: network.NewNetWithPortRanges(network.NetAny, network.PortRange{From: 8080, To: 8080}),
 				},
 				ExecutionContext: testExecCtx,
-				UseMangleChain:    true,
+				UseMangleChain:   true,
 			},
 			wantAddV4: []string{
 				"*mangle",
@@ -361,7 +361,7 @@ func TestTcpResetOpts_iptablesScripts(t *testing.T) {
 				},
 				Interfaces:       []string{"eth0"},
 				ExecutionContext: testExecCtx,
-				UseMangleChain:    true,
+				UseMangleChain:   true,
 			},
 			wantAddV4: []string{
 				"*mangle",
@@ -510,7 +510,7 @@ func TestTcpResetOpts_String(t *testing.T) {
 		"resetting tcp connections (mangle+filter mark)\nto/from:\n 0.0.0.0/0\n ::/0\n",
 		(&TcpResetOpts{
 			UseMangleChain: true,
-			Filter:        Filter{Include: network.NewNetWithPortRanges(network.NetAny, network.PortRangeAny)},
+			Filter:         Filter{Include: network.NewNetWithPortRanges(network.NetAny, network.PortRangeAny)},
 		}).String(),
 	)
 }


### PR DESCRIPTION
Pure whitespace fix — struct field column alignment in \`TcpResetOpts\` and several test-fixture struct literals had drifted from \`gofmt\` output. Running \`gofmt -w\` over the two files restores the canonical formatting.

No behavioral change. No new tests. Existing tests pass.

## Verification

\`\`\`
$ gofmt -l go/action_kit_commons/network/netfault/
(empty)
$ go test ./network/netfault/...
ok  github.com/steadybit/action-kit/go/action_kit_commons/network/netfault
\`\`\`

Independent of #442 (the qdisc fix); can be merged at any time.