### PR TITLE
feat: describe the platform's custom webhook request in the OpenAPI spec

### DIFF
--- a/go/action_kit_api/CHANGELOG.md
+++ b/go/action_kit_api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.10.6
+
+- Describe the platform's custom webhook request in the OpenAPI spec (`webhooks` section) and provide the corresponding `Webhook*` payload types
+
 ## 2.10.5
 
 - Add target selector query to further narrow down action targets.

--- a/go/action_kit_api/action_kit_api.go
+++ b/go/action_kit_api/action_kit_api.go
@@ -526,6 +526,114 @@ func (e TimestampSource) Valid() bool {
 	}
 }
 
+// Defines values for WebhookEventType.
+const (
+	WebhookEventExperimentExecutionCanceled      WebhookEventType = "experiment.execution.canceled"
+	WebhookEventExperimentExecutionCompleted     WebhookEventType = "experiment.execution.completed"
+	WebhookEventExperimentExecutionCreated       WebhookEventType = "experiment.execution.created"
+	WebhookEventExperimentExecutionErrored       WebhookEventType = "experiment.execution.errored"
+	WebhookEventExperimentExecutionFailed        WebhookEventType = "experiment.execution.failed"
+	WebhookEventExperimentExecutionPreflight     WebhookEventType = "experiment.execution.preflight"
+	WebhookEventExperimentExecutionRequested     WebhookEventType = "experiment.execution.requested"
+	WebhookEventExperimentExecutionStepCanceled  WebhookEventType = "experiment.execution.step-canceled"
+	WebhookEventExperimentExecutionStepCompleted WebhookEventType = "experiment.execution.step-completed"
+	WebhookEventExperimentExecutionStepErrored   WebhookEventType = "experiment.execution.step-errored"
+	WebhookEventExperimentExecutionStepFailed    WebhookEventType = "experiment.execution.step-failed"
+	WebhookEventExperimentExecutionStepSkipped   WebhookEventType = "experiment.execution.step-skipped"
+	WebhookEventExperimentExecutionStepStarted   WebhookEventType = "experiment.execution.step-started"
+	WebhookEventKillswitchDisengaged             WebhookEventType = "killswitch.disengaged"
+	WebhookEventKillswitchEngaged                WebhookEventType = "killswitch.engaged"
+)
+
+// Valid indicates whether the value is a known member of the WebhookEventType enum.
+func (e WebhookEventType) Valid() bool {
+	switch e {
+	case WebhookEventExperimentExecutionCanceled:
+		return true
+	case WebhookEventExperimentExecutionCompleted:
+		return true
+	case WebhookEventExperimentExecutionCreated:
+		return true
+	case WebhookEventExperimentExecutionErrored:
+		return true
+	case WebhookEventExperimentExecutionFailed:
+		return true
+	case WebhookEventExperimentExecutionPreflight:
+		return true
+	case WebhookEventExperimentExecutionRequested:
+		return true
+	case WebhookEventExperimentExecutionStepCanceled:
+		return true
+	case WebhookEventExperimentExecutionStepCompleted:
+		return true
+	case WebhookEventExperimentExecutionStepErrored:
+		return true
+	case WebhookEventExperimentExecutionStepFailed:
+		return true
+	case WebhookEventExperimentExecutionStepSkipped:
+		return true
+	case WebhookEventExperimentExecutionStepStarted:
+		return true
+	case WebhookEventKillswitchDisengaged:
+		return true
+	case WebhookEventKillswitchEngaged:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for WebhookExperimentExecutionCreatedVia.
+const (
+	WebhookExecutionCreatedViaApi      WebhookExperimentExecutionCreatedVia = "API"
+	WebhookExecutionCreatedViaCli      WebhookExperimentExecutionCreatedVia = "CLI"
+	WebhookExecutionCreatedViaSchedule WebhookExperimentExecutionCreatedVia = "SCHEDULE"
+	WebhookExecutionCreatedViaUi       WebhookExperimentExecutionCreatedVia = "UI"
+)
+
+// Valid indicates whether the value is a known member of the WebhookExperimentExecutionCreatedVia enum.
+func (e WebhookExperimentExecutionCreatedVia) Valid() bool {
+	switch e {
+	case WebhookExecutionCreatedViaApi:
+		return true
+	case WebhookExecutionCreatedViaCli:
+		return true
+	case WebhookExecutionCreatedViaSchedule:
+		return true
+	case WebhookExecutionCreatedViaUi:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for WebhookExperimentExecutionStepActionKind.
+const (
+	WebhookActionKindAttack   WebhookExperimentExecutionStepActionKind = "ATTACK"
+	WebhookActionKindBasic    WebhookExperimentExecutionStepActionKind = "BASIC"
+	WebhookActionKindCheck    WebhookExperimentExecutionStepActionKind = "CHECK"
+	WebhookActionKindLoadTest WebhookExperimentExecutionStepActionKind = "LOAD_TEST"
+	WebhookActionKindOther    WebhookExperimentExecutionStepActionKind = "OTHER"
+)
+
+// Valid indicates whether the value is a known member of the WebhookExperimentExecutionStepActionKind enum.
+func (e WebhookExperimentExecutionStepActionKind) Valid() bool {
+	switch e {
+	case WebhookActionKindAttack:
+		return true
+	case WebhookActionKindBasic:
+		return true
+	case WebhookActionKindCheck:
+		return true
+	case WebhookActionKindLoadTest:
+		return true
+	case WebhookActionKindOther:
+		return true
+	default:
+		return false
+	}
+}
+
 // ActionDescription Provides details about a possible action, e.g., what configuration options it has, how to present it to end-users and how to trigger the action.
 type ActionDescription struct {
 	// AdditionalFlags Additional flags that are used to configure the action for specific cases:
@@ -1296,6 +1404,212 @@ type TimeControl string
 // TimestampSource Source of the timestamp. This is useful when the timestamp is retrieved from some other system. If not specified or equals `extension` the agent will adjust the timestamp with an offset calculated from the response date header and the platform's current time.
 type TimestampSource string
 
+// WebhookBlastRadius Only present for action steps. Blast radius that is applied to define the set of targets as well as an optional random subset.
+type WebhookBlastRadius struct {
+	// Maximum In case a fixed number as subset of the specified targets should be affected.
+	Maximum *int `json:"maximum,omitempty"`
+
+	// Percentage In case a percentage subset of the specified targets should be affected.
+	Percentage *int `json:"percentage,omitempty"`
+
+	// Predicate Query defining the overall superset of targets being affected. For example: `{"operator": "AND", "predicates": [{"key": "container.host/name", "operator": "EQUALS", "values": ["docker-desktop"]}]}`
+	Predicate *map[string]interface{} `json:"predicate,omitempty"`
+
+	// TargetType Target type that is affected by the action, e.g. `com.steadybit.extension_container.container`.
+	TargetType *string `json:"targetType,omitempty"`
+}
+
+// WebhookEventType The platform event that caused the webhook to be triggered. Future platform versions may introduce additional event types, so endpoints should tolerate unknown values.
+type WebhookEventType string
+
+// WebhookExecutionOverrides Overrides that were passed as input to a single experiment execution and are not saved into the experiment design. They only contain the values overridden for this specific run — variables defined on the other levels (environment, service, experiment, schedule) are not included. Deprecated, as they are therefore of limited use to webhook consumers; may be removed in a future platform version.
+type WebhookExecutionOverrides struct {
+	// Environment The environment in which the experiment is executed instead of the environment specified in the experiment design.
+	Environment *string `json:"environment,omitempty"`
+
+	// Variables Variables that are only used for this specific experiment execution. Constant values are passed literally; dynamic (select expression) values are rendered as a human-readable summary, e.g. `select 3 of host.name on com.steadybit.extension_host.host`.
+	Variables *map[string]string `json:"variables,omitempty"`
+}
+
+// WebhookExperimentExecution The execution of a single experiment.
+type WebhookExperimentExecution struct {
+	// Created Timestamp when the experiment execution was created.
+	Created *time.Time `json:"created,omitempty"`
+
+	// CreatedBy Summary about a platform user referenced in a webhook payload.
+	CreatedBy *WebhookUserSummary `json:"createdBy,omitempty"`
+
+	// CreatedVia The creation trigger that caused this experiment execution to be started.
+	CreatedVia *WebhookExperimentExecutionCreatedVia `json:"createdVia,omitempty"`
+
+	// Ended Timestamp when the experiment execution ended.
+	Ended *time.Time `json:"ended,omitempty"`
+
+	// Environment The unique identifier (UUID) of the environment in which the experiment is executed, e.g. `32009f6e-ff90-47a5-8daa-80f4bb7ae591`.
+	Environment *string `json:"environment,omitempty"`
+
+	// ExperimentKey Unique experiment key that identifies the experiment. Combination of team key and an increasing number, e.g. `ADM-2`.
+	ExperimentKey *string `json:"experimentKey,omitempty"`
+
+	// ExperimentVersion Experiment design version which can be used to identify changes between experiment runs.
+	ExperimentVersion *int `json:"experimentVersion,omitempty"`
+
+	// Hypothesis The hypothesis that is validated by the experiment.
+	Hypothesis *string `json:"hypothesis,omitempty"`
+
+	// Id Unique experiment execution id that identifies this specific experiment execution.
+	Id *int `json:"id,omitempty"`
+
+	// Name Name of the experiment to easily identify it.
+	Name *string `json:"name,omitempty"`
+	// Deprecated: Execution overrides are an input to the experiment execution and only contain the values overridden for this specific run — variables defined on the other levels (environment, service, experiment, schedule) are not included. They are therefore of limited use to webhook consumers. This property may be removed in a future platform version.
+	Overrides *WebhookExecutionOverrides `json:"overrides,omitempty"`
+
+	// Reason Reason in case the experiment execution failed or errored.
+	Reason *string `json:"reason,omitempty"`
+
+	// State Current state of the experiment execution, e.g. `CREATED`, `RUNNING`, `FAILED`, `ERRORED`, `COMPLETED`, `CANCELED`.
+	State *string `json:"state,omitempty"`
+
+	// Steps The steps that are executed in parallel or sequence in the experiment.
+	Steps *[]WebhookExperimentExecutionStep `json:"steps,omitempty"`
+
+	// TeamKey The key of the team owning the experiment.
+	TeamKey *string `json:"teamKey,omitempty"`
+}
+
+// WebhookExperimentExecutionCreatedVia The creation trigger that caused this experiment execution to be started.
+type WebhookExperimentExecutionCreatedVia string
+
+// WebhookExperimentExecutionStep A step that is executed as part of an experiment. There is no explicit type discriminator within the serialized JSON. Action steps carry `actionId`, `actionKind`, `radius`, `targetExecutions` and `totalTargetCount`. Service validation steps carry `serviceId` and `validations`. Wait steps carry only the common properties. Properties without a value are omitted from the serialized JSON.
+type WebhookExperimentExecutionStep struct {
+	// ActionId Only present for action steps. Unique identifier of the action that is executed in this step, e.g. `com.steadybit.extension_container.stress_cpu`.
+	ActionId *string `json:"actionId,omitempty"`
+
+	// ActionKind Only present for action steps. Kind of the executed action.
+	ActionKind *WebhookExperimentExecutionStepActionKind `json:"actionKind,omitempty"`
+
+	// CustomLabel Custom label assigned during experiment design to express the intention of this step.
+	CustomLabel *string `json:"customLabel,omitempty"`
+
+	// Ended Timestamp when this experiment step ended.
+	Ended *time.Time `json:"ended,omitempty"`
+
+	// Id Unique identifier of this step execution.
+	Id *uuid.UUID `json:"id,omitempty"`
+
+	// IgnoreFailure Whether the experiment should fail/error immediately in case this step fails/errors.
+	IgnoreFailure *bool `json:"ignoreFailure,omitempty"`
+
+	// Parameters Step-specific parameters of the experiment step configuration, e.g. `{"duration": "10s"}`.
+	Parameters *map[string]interface{} `json:"parameters,omitempty"`
+
+	// PredecessorId Unique identifier of the step execution that precedes this step, omitted if it is the first step of a lane.
+	PredecessorId *uuid.UUID `json:"predecessorId,omitempty"`
+
+	// Radius Only present for action steps. Blast radius that is applied to define the set of targets as well as an optional random subset.
+	Radius *WebhookBlastRadius `json:"radius,omitempty"`
+
+	// Reason Reason in case this experiment step execution failed or errored.
+	Reason *string `json:"reason,omitempty"`
+
+	// ServiceId Only present for service validation steps. Unique identifier of the service.
+	ServiceId *uuid.UUID `json:"serviceId,omitempty"`
+
+	// Started Timestamp when this experiment step was started.
+	Started *time.Time `json:"started,omitempty"`
+
+	// State Current state of this step in the experiment, e.g. `RUNNING`, `FAILED`, `ERRORED`, `COMPLETED`.
+	State *string `json:"state,omitempty"`
+
+	// TargetExecutions Only present for action steps. List of targets that are expected to be affected by this action. This list may change in case targets aren't available at the specific time of execution.
+	TargetExecutions *[]WebhookTarget `json:"targetExecutions,omitempty"`
+
+	// TotalTargetCount Only present for action steps. Number of targets that are affected in total.
+	TotalTargetCount *int64 `json:"totalTargetCount,omitempty"`
+
+	// Validations Only present for service validation steps. List of actions performed as part of this service validation step.
+	Validations *[]WebhookExperimentExecutionStep `json:"validations,omitempty"`
+}
+
+// WebhookExperimentExecutionStepActionKind Only present for action steps. Kind of the executed action.
+type WebhookExperimentExecutionStepActionKind string
+
+// WebhookKillswitch In case the webhook was triggered by a kill switch-related event, this contains more information about the engaged / disengaged kill switch.
+type WebhookKillswitch struct {
+	// Disengaged Timestamp when the kill switch was disengaged.
+	Disengaged *time.Time `json:"disengaged,omitempty"`
+
+	// DisengagedBy Username of the user who has disengaged the kill switch.
+	DisengagedBy *string `json:"disengagedBy,omitempty"`
+
+	// DisengagedByDetails Summary about a platform user referenced in a webhook payload.
+	DisengagedByDetails *WebhookUserSummary `json:"disengagedByDetails,omitempty"`
+
+	// Engaged Timestamp when the kill switch was engaged.
+	Engaged *time.Time `json:"engaged,omitempty"`
+
+	// EngagedBy Username of the user who has engaged the kill switch.
+	EngagedBy *string `json:"engagedBy,omitempty"`
+
+	// EngagedByDetails Summary about a platform user referenced in a webhook payload.
+	EngagedByDetails *WebhookUserSummary `json:"engagedByDetails,omitempty"`
+}
+
+// WebhookPayload The request body sent to custom webhook endpoints. Besides `event` and `time`, exactly one of the event-specific properties is present: `execution` for `experiment.execution.*` events, `killswitch` for `killswitch.*` events. Properties without a value are omitted from the serialized JSON.
+type WebhookPayload struct {
+	// Event The platform event that caused the webhook to be triggered. Future platform versions may introduce additional event types, so endpoints should tolerate unknown values.
+	Event WebhookEventType `json:"event"`
+
+	// Execution The execution of a single experiment.
+	Execution *WebhookExperimentExecution `json:"execution,omitempty"`
+
+	// ExecutionStepId In case the webhook was triggered by an `experiment.execution.step-*` event, this contains the id of the step execution having triggered the webhook. Matches the `id` of one of the steps within `execution.steps`.
+	ExecutionStepId *uuid.UUID `json:"executionStepId,omitempty"`
+
+	// Killswitch In case the webhook was triggered by a kill switch-related event, this contains more information about the engaged / disengaged kill switch.
+	Killswitch *WebhookKillswitch `json:"killswitch,omitempty"`
+
+	// Time The timestamp at which the event was fired.
+	Time time.Time `json:"time"`
+}
+
+// WebhookTarget A target that is expected to be affected by an action.
+type WebhookTarget struct {
+	// Attributes The discovered attributes of this target, restricted to the attributes configured for the webhook. A key may be associated multiple times with a single target.
+	Attributes *[]WebhookTargetAttribute `json:"attributes,omitempty"`
+
+	// Name Identifier of the target.
+	Name *string `json:"name,omitempty"`
+
+	// Type Type of the target, e.g. `com.steadybit.extension_container.container`.
+	Type *string `json:"type,omitempty"`
+}
+
+// WebhookTargetAttribute An attribute (key-value pair) that is associated with a target.
+type WebhookTargetAttribute struct {
+	// Key The key of the attribute, may be associated multiple times with the same target.
+	Key string `json:"key"`
+
+	// Value The value of the attribute.
+	Value string `json:"value"`
+}
+
+// WebhookUserSummary Summary about a platform user referenced in a webhook payload.
+type WebhookUserSummary struct {
+	// Email Email address of the user.
+	Email *string `json:"email,omitempty"`
+
+	// Name Display name of the user.
+	Name *string `json:"name,omitempty"`
+
+	// PictureUrl URL of the user's profile picture.
+	PictureUrl *string `json:"pictureUrl,omitempty"`
+
+	// Username Username of the user, internal identifier of Steadybit.
+	Username string `json:"username"`
+}
+
 // Widgets A list of widgets that can be rendered in the experiment result view after an experiment has finished. Any of
 //   - `action_kit_api.StateOverTimeWidget`
 //   - `action_kit_api.LogWidget`
@@ -1391,6 +1705,9 @@ type StopActionRequestBody struct {
 	// State Any kind of action specific state that will be passed to the next endpoints.
 	State ActionState `json:"state"`
 }
+
+// WebhookRequestBody The request body sent to custom webhook endpoints. Besides `event` and `time`, exactly one of the event-specific properties is present: `execution` for `experiment.execution.*` events, `killswitch` for `killswitch.*` events. Properties without a value are omitted from the serialized JSON.
+type WebhookRequestBody = WebhookPayload
 
 // AsActionList returns the union data inside the ActionListResponse as a ActionList
 func (t ActionListResponse) AsActionList() (ActionList, error) {
@@ -1831,155 +2148,211 @@ func (t *StopActionResponse) UnmarshalJSON(b []byte) error {
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7H0Bc9s20uhfweh9M076ZNlpr73v88w3N77EuXqaNLnEeXk3lzwLIiEJZxJgAdCy2vq/v8EuAIIkKFGp",
-	"0/bea2fayiQILHYXi93F7uKnSSbLSgomjJ6c/TRR7IeaafNXmXMGD84zw6V4a6ip9ZvwcmtfZVIYJoz9",
-	"Sauq4Bm1TU/+paWwz3S2ZiW1vyolK6aM65Hdsay2LS9z++dSqpKaydlEG8XFajKdmG3F4r/vjlfy2D2s",
-	"a57P3r27fBY/P+ZlJRUAUlGznpxNVtys68Usk+XJSspVwU7sh5P7++lEG2qYbfofii0nZ5P/cdJg4ARh",
-	"1ifNrBl8ZNHCFcsnZ/9swe+7+xiglot/scxM7u1XOdOZ4pVtOzmbXK0Z+fbq6jVxOCYV3RaS5qSiWrOc",
-	"GEnMmhEKQxMNGCdM5JXkwuiZRQw3hR0DoSNIFOKoMrmfTl4rVlHF8P3DUCuTYslX8FWec/sJLV5HLYyq",
-	"WWqmbhr4ea1gsBm5WnNtnxnKhYbpMpEf15qpdkuSS8HIUqoIJTPyWmrNFwXrtK2ooiUzTGlCFSM5W3Jh",
-	"8blWsl6tY6RGYM4mPZJNG9I+tci6M/vY5KLbPu7jt2HvNvUOo1lWK8WEIU0fRC6RSncVU7y0L8P8Jnau",
-	"tKwKWE0X//v85esXF9dP3729evXy+vWbV68v3lz9Y3I2ebqusxvyvVSKa0KLQm4s5Wnc032CFoaqFdtL",
-	"gStstXuNOh5uIefhV2yFiy+9ZN3KJG7pRmv27zVT25fMKJ7ph16y/emUMBD5wQ7677o4f5uFdRg/WsqX",
-	"TBtaVn1CPJeKbOwKCG0AD442t7SomSZ6LesiJwtGlH3Obllu0RKmnVPDjm0HvZnvXgwNXGFhPOBaaPFX",
-	"sxLIy7owvCqYf+NB0mRNq4oJYCd2a985dghN4mUEi4W41RKvoreGKvOQ+94fWspOOmuL70CqlMQDiiTk",
-	"3Vsjqz8I9SsSSlZ76CSrHpkARl1JoWMr4AXX5o17fBDFqNi+Wk7O/jkGS3aQyf10TNPvuLlQSqrJ/ccE",
-	"gjyknZ2KFFybgIq+Vm3HJ2GW99OOBfTZZh8GqIvPNP/kmt1hVjQoeAYdL4Jh8ZlZ4Fk0j8+CidzNZwcy",
-	"/JSbpdGgo2NmfTZsuHE+J0+0dFc6hIye9trgoq2+fjZUdIb5bPhI6i9DCkiMh5YC8jmFhDK/pYzo7Orx",
-	"/Jtt/TNOX1afd/b9zXJwq/Rzt0oADtrslLEE66n/r5W85TnTJGeG8kITupC1IZRU3oRCEKaEzVazKZoK",
-	"batKVqg8c0PWVE/JWm7shl8ppq2Nzo39y1tvmlCR+yZG8dWKtUy3ybDX4HlBV7o/g/PQgCxtC7TnrYSo",
-	"nerhwWWxlLFo1hXL+JJnJKOa6bMPgpAvyPzZ5dvzv764uP724vzN1V8vzq/m5Jg845pabNge1owqs2DU",
-	"kAUzG8YEoSs7UzuzqqDGqn2OjFwHi7K2Kl/LY8ENK1FtFHVp1a/eyJHy5e2p8IAqRbf274watpJq20fN",
-	"O4sAC4hrwn90FFvGmNhws+aCgG3NhWFqSTOmnQnOtaMvLWB+pdSm2CJqqSa6Xhz78Qlfkowpa7G7rmPD",
-	"caVkXQE9VsysmbKULundCyZWVq398uuvE1PNd7FuxNdosQUWM5KsWQGGbElqkTOljQUe7dxm5lyTXHKx",
-	"6sJyenqaAGbNhRmnXH9rW95PJzxLwX0uiH2BfMp1YFOeM2H4cku2slYBRAEA13xGvmcsh7lZXYHk1NDj",
-	"WnHvJLHMRQXhJV2xznyenMI/U2tBGKYsDP/Hfn42++I/JomJ8jwBNDEsWwue0YJcPuvBXgv+Q82KbTMJ",
-	"4H3bteU275f5h6zJhheFfWG7KrZkQwUIiFozomXJLC+uSMFvGJlLtZo5t96s3B4vqci2x9QYmt3MR/HP",
-	"DRf5OJJ9Z1veTycFXbAiNf11XVJxrBjNQQ5Au67faQxIuKnrfVC5Xf1pLGnt540LKyHLG/fWKBlolzjT",
-	"LHaLAXHAzWNXDcsb/oPV71/f0oLn1KAXKIix/VgOEAIm6N0lfvrNnzpSbTpBhnLvjaoZuJNB89uLutpQ",
-	"w8Xqwm2ab9iSKSYyUA1Ap/ilPZhaf3IX77lZP6VFcWkl7S0tsEtZ/SKY0B/4lhUs87Jyv2Owad7v4YqV",
-	"didzW3BRjNCHroZ6uP9oBXmlmN0ocu/xvztuntllpf2OReadnma61+eccKENo/msgf0KGOinxFB9p8vo",
-	"oZuuO0NaYSgLuXrwXfdSwB6LKskUxahfdvbzZmRc5HgiYpjQbkdDBc5ugVTkBZvi3ohSlMzP37+dT8n8",
-	"u3rBlGCASqnI/FupDfyiYkuyWhtZxiNtZQ3SZKO4cRtNM+ZSjtvMDS/ZUymMksVeBo2a3k8nt0zppApw",
-	"tWbEvWyjd0besJKVC6tcSsJFZsmMCASXNrp3LUQwt7qy0syZ40suQKEEFYg1Gh1Qga+EVAzQ1LQk2ZqK",
-	"FdNAVFTeaRko7QCckfeM5JIolsmyZCIntaYr2B41K2+ZIogq3UFmJBwbXG54vmJmrxR675p1/Xw8n/it",
-	"rsFuW91ym2ebbK39pxHIXqx+7PlvnrV67B2jROpSj7b2qW7tYRXaKqQxCQgX6GO1Yzkno11RQLktfJzY",
-	"yTZrJkJTgudMsDla1t5li0QWZPKQuaYFsVoiMezOkEcZFV47IyVVN7nciMcz8t6t5pzrqqDbBrRKybzO",
-	"DHl3iSAOgzVgE3TB8iMBAvuDGOlhQLPGQm51d5LzJWwu1tIrQCjkyNrxK6vDWli88WI/v7b0mKCqfL2h",
-	"ymqlCRumw43wdhqw+zEwxndOfUvp/Qu73KwAtGza6JgoMHlkvnjuAYsA7YPIJLD/ZgXVGnVWKx4Ul7Um",
-	"qhaCNvZvpFJVVBkYUERH0TEmUEO1M1oz+H8haX5tmLb2u7TGT9Ku63gJUnYDE2sqMpbHQu/N86fkz/95",
-	"+mfyWslFwUryzFnyVu6DU/789aXl8bIquFW2vTOdLGS+xd3BDkh0xoSdvO7xPfoGRmjF7K4qqMDlGIxr",
-	"WJfWjszwTD9jXlZXCHGSo+1ua+eaGvXdm0uivP7jbBG0OzjDw+Iw+GGDNrpdzpa0LszkbALIYfmk67D5",
-	"giwpL1hOjkkUY7Km4EphmWE52DPQqlZ2L483YgrPYWUzbchmzbM1fLxgzFpxVcEsW7GcLLZdlb1RIXB5",
-	"W/WxYvnUGuCAaRevwzVRzNRKNL10Inlm5Avi5ofTsHs81YRG1h4yx2bNgb7gvWjLoyDQrIxDt0Akb/32",
-	"+dCQR+sN6WAfOFIlvSa4MfWZSa+lMtMuJ+u6LKnadpgGDNoDBPAYVt3TdVdWwjSijda5FKfRsVgfDvsU",
-	"4l3a0iymzwn6sDLw1yCdWcIbh5/bn6PMPierB+2WfUZfZ/Z++I/Jk7JhDaOxO3tHtjTLWGVY/pwXzOr5",
-	"Cbv6HYBFlnYFgEfDSRe7leRhgs675DwetjFqL34AWP6RqW05yzY+sk2PWoZ07Lv58j9TToRgOn/15SjT",
-	"mea3sHEkdIQ1uONw+QXwIsddVVC748Ce6eOvqMBV4rslmrWsmka58pZNxNkLKQtGBfr3QMr+L6uSp1aP",
-	"e+909uBSDWC6XR5fb1razrIBIpdMEyGNo9uW0OEOx3klGwtzCJ1SwYgdrHLLMP7jGXkWfqd8MGue50yQ",
-	"pbK2WA+hfRWREsE2RBtWzcjFHdcgp+2frkttXMfoyEaXW54CYUbOky88V9iZgZMIVyYRUpE1vQW3ZETR",
-	"IZpjx1yKl0xbEyhF+RJfoZwK28Vablp6flDlUdcfUJh9MJkFPd6DuciK2toTTmlHjFCiGPC8V+s+t1c6",
-	"Pvoc4sO0Rzp3jsF3gpuE3HoWvyZvndDCXaeGZ0Gn3Suk/FBHlmuBxCjdjkpeFFyzTIpcH03JUfSz5KI2",
-	"TB+NdhLGALfF3JPTUWLucBf9L/H3Hig2Sno3IOggGJILXtblDlH3ShRb4k4uLUgDpJpbEbFiaj4l84qp",
-	"jAlDV2w+BVNn7uk4B0+TnUtGNexYzatp5CexNpQgMZGjJeFGgslx8f/u5AQtByZ2w7ZuZ0QNPsUcBPRa",
-	"q5g6SWQ/yigAKKxYW8raGdjBRscQBxdNdeQ9FGTJWZGPYjZ3KNuH+pU/zfPHtp6n5/ixxSz++ufHOaIV",
-	"/7yGhTeP5mUH1TPyHmau4Cjc4lPXqxXTTedBAs7IubAa9dkHQY7JHPF0fcPNNa347OLOEp+boKshpPNk",
-	"404j/VzJEn2358YovqgNm4+VOp2+RumlAcGWb1v2Yiqe/RkEGludxOKDIiv/NzlCxB6hb8V1CLaQtKvB",
-	"EsUTqVHHIGid5eCrLbQkS8UY+JuCYLb8ZqFIb79S5Uzt9JN7xh9ylINTVGoen09CHBts09b4VaWdLsBv",
-	"RwOPeaPG71GZmg1TMPTcjFPb+lMdcIrFTiPssK+lZbQyoEeg2Ypavz8VIFwsi9raMLiXznF1zn20I9XB",
-	"RwSvQ+gUrGYrnAzSDtcMCCFeVkreWj1bM3XcaHkM/QA6tnfDQYZfp+HntefYhoYeH9NJIy8njeowmU6s",
-	"/TGZTm7Y9hrQYRleFRaj7M5QxajtHkOypO1xzWiOXXOjqEH3r2Jai9XxRqob9A0rtmJ3E384cxyQt98d",
-	"6P3SIHVd44+t2Ed2WDqJlTodL2HwD0GMa1vLbMesCnZn9mY+saTpqQxf0ixhjp87I7ykW5KtpdSs5d52",
-	"32nyiCrAsdqiPfm4UdgKajnVqm0uTGexdc5NUIm5sDM0GHHST5fx0T5BNS4ZcOGainwL4Tp3lYUKYnjB",
-	"QaVYJZXB6B3NS15QBSEIfReBfdqf8oJq9s2fCBOZzFkOn3aOOf7rz1+dfpXScgdUtG93KmgOh3Do0py4",
-	"4FkQKP1L9Ge5Qywdb79NV5QsmLGIhlWJmARHDiA5lxthMeTMDR2RzodLBc/vNa71maFqtvqxt4V/M3ZR",
-	"AOJi94dnsh0MON5dE3q774+gJ/3QI7fj/LWg2ryhOa91Wk3ydvzCNiQKWnaiyLopPI9c32fkyekpcbLr",
-	"cY/bSpkP6ZwyDz5fRUUuS/6j1TQvl0QzsPbaGqTpnfVVPLshwo/t+0JJZgUESDbd6rGkd1bRdd01w/q+",
-	"/DeRNG+JZfd90oN5m9avLxEsmK7VNIfmFlRemGh4u3NaqY7bU2z1Kmo4cbU9NvPsqtMdxgYC+sl9THDx",
-	"LhdiXyhcXb0O0jrSyd8aRvPtgpu0v9PKh1pwq+iAIOhLtZKZtdwbS/SG0fxbY6qX2BridewC720ACy2L",
-	"2ti9xmp+iOgW7ABBE651kgzV6qASxpp6UCMhAT177JGWB7Zlcvfg/G19Bn6FxM1BF/G/XGOrk8gatI6c",
-	"bnV/8VhN1nZ2fEuV1So0BFtGM3/ZHiF+9Tb59GUYOX76rYMifvYMILqfTi4S+bx9qdVs0Rk2a5Ig47Nu",
-	"F+QR5ck2H7YDIfoufMv35xt9nmWyFuYyTwNy/v6tpbBtQi6fhU5h0fjov/RxUIgbtUaMlRrhvL0Ju3QH",
-	"DDmxcxHxYCmHG4z6mg9AWilptaDDoEza+Z30rV3UaQbrEWBP3+8U39f5uzeXY3pvENToeN+x7VDvQQ28",
-	"YdtELrVHlxux2JIFayKWMdRvx8A7phWGiOb1SwdWzP62G5aXawnVI7zqxEP6I1Vgk0dstsIIyfYeECuH",
-	"cWT3Yx82+VQKwUKcMy0K7xenyyVupYttOG87IRgVoEc7Q9/0ZtgP/k7lqgc581Lm1sSh3k89Lq0h+flb",
-	"ZpyRtUUv376Mh2Qv53kOX1/JF1yHDl18YDfSISyGMuoBiDXzNQG2Lm7rsfMrfRAk6VcaMaH5Ad+mpzGP",
-	"LMM0CYZoM4CWVKKDDj4QIwlFr0tARmTBpGy+Ix3VUuhvC76bQQESSQ3fdkykWtoJE5wqMiiZAR/tSHev",
-	"dnYoM0CEVhhOnqND49rIa4uqaw/3bvX6sDoVDTnyvF8qoJ3hG9w6P90PBUHFZIi14l2cNcBAY2VDb3H3",
-	"1UBmImVfLgn9/5TremKj5ZZjDYddd+2Zh+MzzcxvxGc9RhnLYamsLRRecjkg6XVa1OvfjawftYcPbgQ7",
-	"8ZzytAycjvQR+w9Zw+ESHGVDhCJ8d7Lkd62jfNkcUVNyI+RGkBMCAc3I/XIZDh9AeRLslikX6Nxfx4cd",
-	"o0ZBMxgZWI1On7kdPmRsQtZcPAhY/2mvrrNEup5678hHfh4B0ICXzq2n++nkBRfs6Zoqg6HYKRRhLDdi",
-	"Wa/lRsPOLphFtjJ9XEMmnR19D/N1hv6b+wxTijDPiwnDUdU4oKNL91nT0UBsHRDFvvL4xZk6C3EzFAbt",
-	"8IHHDN1UtmQ4lJGyMLw6cB5X+FU0jVGbhp/EiO3iqSyD4wnHDCC0do5MljPtG87cAJYFroEFRkdQIx0i",
-	"wkYSvcuICdmdYpgUwwIDWnTk1FDiLKxwEDjMuBBMnkYwxpk7DEP/HS5p8tgKnx1PTQa5gnuhCGVYEIBk",
-	"aIbJ1ngseuiKeuk+PWAZpObXWwWOp4mPEKq4m1E3NHXToefOwNFpwIGf8jCLIP1H8snLBoPj7MwdnTyn",
-	"RbGg2c1eK3NHH9+x7cUPNS30OHt1R0/fS3NRVkk79cqzIURGovh2x/SeX+E1JhZFbNpp3OxBXHvuCGpO",
-	"X1MZgbr5oR+28XXw5x5J8z38EUibECtL966NUlggiEVaFH0sUsXA74Ifoc/Fog5CChCXPUH0awr6JHUO",
-	"EP4zmMO1w8m1R9LIPeHjYcu3s2pScZkjabOBXIKW0RjlZbAcDDsGY3Ve3PrQ0TbNbtBC/ERL7+Fp2Vkw",
-	"n07RG7a9RkSMMRpH6QE3HaPuAA4I0u5z055jSDazg/3+qR3k26fTWUhzDbMdrc5ZJIwlX6PYD0f8tQ/c",
-	"jXSKHGQp7VaiCIyhwbBcOG2NYfIcDfqIe4lB2hzOdV4HpQXCaJzxtde42ekvwBbdLbSnP8XQX9Bs7Sab",
-	"nIFnbPcy1AX99O17rIMgqXIlarxYpL5FPCcjADx3G1VDNGykLraD5wfogJnO7W80VOlZ93KhHAEgcxIR",
-	"5pWdJS8MU/sV8m6oXof9HQ/s0Uwbjt+/RDomay8JaKlkmRYrgpbO4+mqcUEIbqvoiit+0uR1KVJZLDAN",
-	"yRHN1GNf6bvL5LEWDvL9YLyxB6cpD9bjxkwKzTHlOQRKJtEfjZoMosH4D8VAxSp9zVRXEXaxJcz+hJoU",
-	"ZG4ROMfSTw6SRg7ruKDIX1Cz3Cc6vQV7bUFzBSDm5JicE83FqghOAkgUdAne3lLCIsFUuJCWaCPaJzMc",
-	"HJ8CIr4/rpg6hrEcsBg2mQTX8siK3zLRaDxjN5YUdsC0+yUQ79+WIuac4pJxrDO8UjsLb/9KbTtl+tl6",
-	"wWf+dCgXP6oH5jLK99Ld2do+GrIt1EAMDpQcaMIw9sq8T9kOGmTAVBP7ApIEXdRp70PY/VsuiLi882j0",
-	"DAssACAdQhTGrwU3Dzx8Nzu0xxzDjNnms0P40nPdw+0gjYBqisb1mDiddTzS45Tobsj9RDH4PQ7JdDF+",
-	"+5mhHsEB6JWP8hnynOUttWTkcAP+LSDEGLoDHVOEl6tDfPWFXPlkxcT5ZiFXV3tNFv/52P2psWtQPZ0b",
-	"V5+oZ924BMv5OC/6b+3F/xVsO7kaYcHJ8TVLPH2n/cT8ho8STPbSlYMZx2moM2jiv4plQmd/rCqWqpnS",
-	"NxEiGgEN8UuMOfPbpnTH+i6X2D+XS1IpdgtlUkKsbUaLQs/I8ya/dgqllexuirUc0NC0DMHFKuyScygd",
-	"NIfvpx4KaFkpuVJMtwMfo69MrfEztEVoHhujTTtZYatWnPaSFjqFBYxZ9IYPRKvrelFyY1ge5r+wq24a",
-	"KloutmQeLjKYz8irIsdbKqBxb4FMXeZ2wbMbi1XpBB0vGWgMDnJVC3LL2WZGrqTPDvKh24AOkTkMO4EB",
-	"oDtMB4ni0uA9MGsr3eEIF2KeK6qaI9FAUpheOqPK9fuHSPv9iDQvE/bLNV+C6uDjxJjqUy9iIknXEWYp",
-	"cTeU6P9Cro6Tqf7t4/qQl/HIZ5Jg7GYhV4/7QhAUrBEVNmHY59j4fjop2K2PYfC1f1w5K4/WnC3qFWTX",
-	"weMNVcJXnUl6bctm2slqeOFKljEXqUSfvJW1ytiYInpx8xY/+hme/+3i+6vJfssPJxIT3T0apvbzQIZ0",
-	"pNNPeyor7MzbQxq3eaZb6i1wjT9LlUvS2pXbUyEO4OEZ6Z0MrH8JB48yDz3O73uwp0KGsIRsH2R/Y42z",
-	"czHVLw5W9gHOZdTQ56rbRaLoCtu3alu4lEOit9qwkizYmt5yVzzOyFBFuthaq1mZdF4ibo2uiLQfnypG",
-	"5EIzdQulomZsNm3BRjNjzZZHKPEwpfMxgeJrOpnJ49DyiWz5HdueoI1SUd4uAdTYtm4vATHPNSRRFda6",
-	"WhqmyGsFhY5ZrY/QcQCv21PDUCmNNZNLunWpk7H5DJYl1WR+fW1/Xl/PQ2qmkeCLawbCIjjcJG+zStc3",
-	"eNmMglAArgvDlKCG37JiJEyR19M1iiM5dwvGzsYZrqiKcE69TVlKl07gTcgN1YFvxl5X9RBStntYh2lx",
-	"nRjNZSGp+eZPCTu2uRLLsWoiPvOlf5MQVaG+9EiZAj3dd/seliidotQ9VwjcVzGyvjVcYdEpct0HhbRb",
-	"DM860V3/jiafTfGQFZzbZbk/tSL2oeXQomshIgA+9vGHN4Xsx+JgjenfW6Klh/TfK9lyPEuNrrq9qyx4",
-	"7y7GzggdNBmsYLeEqjMi28YnOVgmIdB7wcCkZvlfyBW9YZr4VM9g1qOshdI7T05PS1dm+smpnneQ/eFD",
-	"/j8fCf1zqX/WP5c/r3/OH6eR3+HWXjDWA3LkAaSMGDC6yOP1q7dWqX79zv732cWLi6uLpIGQiOYem6WV",
-	"DgffF+c2om7O5P5jH7Jkw2TZNkN9aLlzXbl7YLD8JOaFE+r78MeJ3tV8w7bpaznDB6EEUsfxNQzVVXdM",
-	"OwhU1WuYJNx20w2QR+1zReEkND88IryB6yNe1uVmN+T4a1UcD6m/1Ifkr+HUXVk1MidV6M2ftAYPBvoO",
-	"rfLpL7nF4nZSeK9DmUrGaUOHWbC/BydHg7f9bo5mFqMdHYmJf2xdONYmWmLnbN+O1j+2jCtxjCnAAQ4J",
-	"5utAH3K3VPA6jLUm9eG3kriYgXZ+z8F5MHrySVdWTie6CYTZeUGXa9Yl+tC1lr374x6QlL8GTew8OwUo",
-	"oi3pbxfp26QSacb9S5x5nqpHTp5ePnvTuwrIZ2ajVxtlb1M6C/JWgxdHMLOR6qajEjz65+nxf3386cn0",
-	"q/sPH2aPf/rqvnnw6MT//vL+8V+S1xeJUdEzlZKuSvdFKIb9XKqmWPMJePtW1sSsalVJzbCkQdJoraQy",
-	"L+ndQCUarJhCbCNfI8VjzZdzQ4FY6xC1wxq4orowZ998/fVXX0PlC/z7NFVrAKDhYnctxl8NmloVaUje",
-	"vXmxgxp7NXBXHwxrlQGLNjNvKJJa5/HNhX/I6t+brE6Ry7BXt0xd8ZIdlkeHdotcEnlr2ZyXicjysWlw",
-	"CTD6qXAhEfLAnl7Y75puRqE60Q08+rdLzEtM5LdIzmuBsV/RBBpdW8a6Bl9iand1su/Ayb9TESsEb+KB",
-	"nUBMlu9mZL5gcymQp1x8C3hz7WpvOY5btb9lGC5G4Cq52RuF28FVN6Bo/7zGISNe8Q+MiWTS9a+FjHhe",
-	"4zARC60HD6zzBZRwJ6AGssP8RvCLJxuDPm6yewJcH2q6IX30gSe8N25ypzh7YD5/9+bFjLxfM0HoLeWF",
-	"ZfYp4YZktLbaOvUJs2xV+nimWgnCBVgh623FVMHFTRoxO5DQTGgcAmJR3EPBmudDJVck1HGGwzzePmbz",
-	"N16ExdvawdEaW9YFnqeGatJGUaELuNMBl0MrskoTxQp2S8VQjsYOjMQzHMBJ/cAmNVxoxZKXcDTFvUCX",
-	"sTzDBSKykkWRuk+IUE0KabnKXZVle7Y4gUgxOMQW0t2FhMUwkwFSf5gBn8Vl09D6o7ve/Q/r7WCyHUoC",
-	"i+mhlDN3bVYIt2xFvvQMh50lqPsx000cVndT0OyWKW62EIZShMRSBCJW2KMIreQVhMmKoG62L2zfl9hB",
-	"/Oi97+weS6MPVaHBSPYUHiJAI9Pp6ydf7vVT2+F8hFq8QTv6JEQunnoMwIheOYi3gRMQCTE0WBAn6M8Y",
-	"EmRnkVkjZ7vj0GVnlFc4Dd97k30PUh2d/OhQuhs5B9CaSsVxs3Pl1NvnSM1kSK97qlh0L7m/4T5KnWjd",
-	"0RR2Xl/U1F/ZRztVOvthNqPcWhFuPw6St3Xjc+IW4ujyBH+vJYUoLe3XTtdBG8o+u2nlUhwZvImB9hq7",
-	"64mdZobhZBKDpRN14ZO1wndfHtf7Am6a0ZqLFfjqd8w/LjveuJ9bsw6H1e8uCV/a/R1CV+z+HpjHlQrF",
-	"S2W/IEeOB69pURyR83Ci2XhNQh3txTaMH30npGBHIQjwMflejumhJdkCABCJ2nQ7Usq9TOHvEvs5h053",
-	"tfgeBrqfTn6oKdi8/vwgSYRv5YaUYH+4OTaR4PEsGwyDHqnPyAdBviBzdkczU2yvpYB8ygv8Ew4xHSuW",
-	"tTZxb5jIHMUTWpwuKS8sgUsJZQmoiHsAZc59jKPSooDszaLoFUVvlSPCsWqOD+F+OUgVjIurRxXgvSO9",
-	"t+JwVOEm6Zh+5m7jxPIm4VDFpUDA/WShx37Z9RZknwZVxHIRGaxgAh45gOH+3ucUR8lX0GHiPfJh4kVg",
-	"P528qf7T7qf3l5T83QeuDWVQdg+zUFzUdrE0YSZH2j0vqFjVENguybJWUJBGUKXkRsPVEa4jvI3PEy7K",
-	"nzkjdKNnriz2f3+YfJiQ8++fwcMfpWAznuND+wmwdno7bAMzJVUBV6H7cN0Y7lxmddjCzj4IQtbGVPrs",
-	"5CSXmY48oJksT2rNjsOTExjl2I/S8Q2ffpms0dm5tr93SY/DN/h3MSvSBYEHISLhMmo4pJoRLNXhruTh",
-	"+dztS26rnvtro6/CsG/cRcghRPWZ1w6+4yPOnyL4I5WsuzHv37s9J/aNmZ0XDb6QYsVU4oTVdUei5p28",
-	"LLzgpaA+x9J9caT9SedsFAHHXcyChgK0HXVm8EN6FV6lTpPDfu3jYPatxfYCsxw+ao19EL/DRfZBjKDS",
-	"QIFKRPIw2waeHM++OqmDKp8VQdEB52vQQHFS2lwaG7RLu57CzV9I1oTm2VLqEfnvLolUPXJfNEXcrYLq",
-	"OuyvFt25It43rK151Bl8fA33Iaze70V8Kvz6ipfsqRRGyWL4Tik7S8Zhs1kAkvEidUMFg3zNWyaMv50I",
-	"8gwZJGCiq3UttZnC1XJInFtra+uKCnC4whkqFaQWTSknH/iJC8uspW5uzF/TW/TT+kZTsrEmGAhtYbgV",
-	"UgtmNnDjuYC8gqLYeuA2lEPWKVaozVlVyK134y654HqNtz6yu91fwtVNDcCGl+gIpFpPwTWoZFFEM9Ft",
-	"P0KEPHevmh3MNnHjJs/9rvpJBB3/LjwP9ohvnnbgtpq4y9EVZ7d251OyxHRZrHiH2TdgxTU3HnO8L9CV",
-	"W5uHiw3mpOMppfm/rELdHg+Xp7WdlppBom9WoxM5XE2s3E5KcktTPCBuKle6cMYj3ZxOuOOIRsN0EO3D",
-	"a3P6Py5ONnVWubcWZEgR29eyk/i4N/i2G0h4YFXK1E0JragHZ4J38+Ai95u7pfOWs43LRcIa0f79mmq3",
-	"uKx9s6vUdgKzA4W1Az4H3rexONCoi7uhsdoYiy9lCDh3v3YWGfOVi/5A6xBaR+1/Dc7bVOjvbvdwoiN0",
-	"7YxGdxWwheLkXxqvjQSn7tlPk4JnTGjWxO4sOVOTs8nLyyt/bST+0Tqz8lkAwY1Pzl9fTqaTW6Y0kv/J",
-	"7HR2ipfnMkErPjmbfDV7MjvF6MS1npyJuijAr5XX2RCc9/83AAD//w==",
+	"7H2Jctw4suCvIGpfhO3eUkm22+6xXrx4IUvyWNu+Rsd4XrS8KhSJqsKIBNgAKKnGo4j9iP3C/ZINJE6S",
+	"YBXLbXf37PZEjLtEgjgyE4nMRB6fRxkvK84IU3K0/3kkyM81keolzymBBweZopydKaxqeepfrvSrjDNF",
+	"mNI/cVUVNMO66e7fJWf6mcyWpMT6VyV4RYSyPZI7ktW65Umu/5xzUWI12h9JJShbjMYjtapI/PfdzoLv",
+	"2Id1TfPJxcXJUfx8h5YVFzCRCqvlaH+0oGpZzyYZL3cXnC8Ksqs/HN3fj0dSYUV0038TZD7aH/233QCB",
+	"XTNnuRtWTeAjDRYqSD7a/6kxf9fdJz9rPvs7ydToXn+VE5kJWum2o/3R+ZKg1+fnH5CFMarwquA4RxWW",
+	"kuRIcaSWBGEYGkmAOCIsrzhlSk40YKgq9BhmdsggBVmsjO7How+CVFgQ8/7rYCvjbE4X8FWeU/0JLj5E",
+	"LZSoSWqldhnm81rAYBN0vqRSP1OYMgnLJSzfqSURzZYo54ygORcRSCboA5eSzgrSalthgUuiiJAIC4Jy",
+	"MqdMw3MpeL1YxkCNpjkZdVA2Dqg91MC6U5vI5LjdPu7jtyHvJva2w1lWC0GYQqEPxOcGS3cVEbTUL/36",
+	"RnqtuKwK2E3Hfzt4++HN8dXhxdn5+7dXH07ffzg+Pf+v0f7ocFln1+gdF4JKhIuC32rM47in+wQuFBYL",
+	"shED56bV+j1qabgBnK+/Yyuz+dJb1u5MZLdutGf/UhOxekuUoJn82lu2u5wSBkI/60H/VTfnb7OxtqNH",
+	"jfmSSIXLqouIV1ygW70DfBuAg8XNDS5qIpFc8rrI0YwgoZ+TG5JrsPhl51iRHd1BZ+XrN0OYl98YX3Ev",
+	"NOgr7AT0ti4UrQri3rgpSbTEVUUYkBO50e8sOfgm8TaCzYLsbol30ZnCQn3Nc+8PKWUtnqWGt0dViuMB",
+	"RhL87kzx6g9E/YqI4tUGPPEqgaaPZLbk/PpLcbQOGrbrD2a+W61NaglEcZTVUvES3ZqewsLQ7ZIwzUYQ",
+	"RrKe6T5nJEdVgZUmDM1hmEI8y2rRAIKdUgAAIElWnMlYDXpDpTq1j7cCB2ar9/PR/k9DyEQPMrofD2n6",
+	"I1XHQnAxuv+UgKKbaeuoRgWVyoOsq1bo8ZFf5f24pQJ+s9X7AeriG60/ybTW6FUBBEfEkJJjXN+YBI6i",
+	"dXwTSOR2PWuA4ZYceEMAR0vP/GbQsON8S5poCO+4Dxgd8T3Aoim/fzNQtIb5ZvBICnB9ElgMh4YE9i2Z",
+	"hFC/JY9oiTXx+oNc8w2Xz6tvu/qutNArK7i1aynIDBpOypiDdfSfD4Lf0JxIlBOFaSERnvFaIYwqp0Oa",
+	"KYwRmSwmY6MrNdVKXhntgSq0xHKMlvxWywWVICAiUJASnPoqEWa5a6IEXSxIQ3cd9ZtNXhV4IbsrOPAN",
+	"0Fy3MAYNzSFqK3u56ZKYy2gwy4pkdE4zlGFJ5P4lQ+g7ND06OTt4+eb46vXxwen5y+OD8ynaQUdUYg0N",
+	"3cOSYKFmBCs0I+qWEIbwQq9Ur8yLNwaNVHqVutYyb8NkQxUpjdzM6lLLn52RI+nTKZT+ARYCr/TfGVZk",
+	"wcWqC5oLDQA9EduE/sNibB5D4paqJWUIjAuUKSLmOCPS2iCotPjFBayv5FIVKwNaLLVgt+PGR3SOMiIU",
+	"psx2HWvOC8HrCvCxIGpJhMZ0ie/eELbQcv2TZ88SS83XkW5E10Zl9SSmOFqSAjT5EtUsJ0IqPXmj6IeV",
+	"U4lyTtmiPZe9vb3EZJaUqWHaxWvd8n48ollq3gcM6ReGTqn0ZEpzwhSdr9CK18JPkcGEazpB7wjJYW1a",
+	"VkA5VninFtRZiTRxYYZoiRektZ7He/C/sVahFBF6Dv9Tf74/+e7fRomF0jwxaaRItmQ0wwU6OerMvWb0",
+	"55oUq7AIoH3dtaY2Z5j6L16jW1oU+oXuqlihW2zUiFoSJHlJNC0uUEGvCZpysZhYu+akXO3MMctWO1gp",
+	"nF1PB9HPNWX5MJT9qFvej0cFnpEitfxlXWK2IwjOgQ9Au7bhbciUzKEuN83KnuqHMafVnwcbXoKXB/ve",
+	"IB6otziRJLYLAnLAzqV3DckD/cHud69vcEFzrIwZzLOxzVD2MwRI4LsT8+nz71tcbTwyBGXfK1ETsKeD",
+	"5LcRdLXCirLFsT00T8mcCMIyEA1ApvilPahafnEXH6laHuKiONGc9gYXpkte/aI5GYPoGSlI5njlZsto",
+	"aN7t4ZyU+iSzR3BRDJCHzvt6uP+kGXkliD4ocnflcbcTnultJd2Jhaatniay0+cUUSYVwfkkzP0cCOhz",
+	"Yqiu1Wnw0KHr1pCaGfKCL776qXvC4Iw1IsnYsFG37fTnYWSzyc2VkCJM2hPNCHD6CMQsL8jYnI2Gi6Lp",
+	"wcez6RhNf6xnRDACoOQCTV9zqeAXZitn0YlGWvEauMmtoMoeNGHMOR92mCtakkPOlODFRgKNmt6PRzdE",
+	"yKQIcL4kyL5sgneCTklJypkWLjmiLNNoNgAEm76xb+sZwdrqSnMzq47PKQOBEkQgEiQ6wAJdMC4IgCm0",
+	"RNkSswWRgFQjvOPSY9pOcII+EpRzJEjGy5KwHNUSL+B4lKS8IQIZUMkWMCPmGGB5S/MFURu50EfbrG3o",
+	"pPnIHXUBuk1xyx6eTbQ1zp/AkB1b/dSx3xw1euzcI0XiUge3r8GIGJ9hldFVUFAJEGXGyKzHslZWvaMA",
+	"cyv4OHGS3S4J802RuWiDw1GT9jpdJNIgk7fsNS6QlhKRIncKPcwwc9IZKrG4zvktezRBH+1uzqmsCrwK",
+	"U6sEz+tMoYsTM8X+afXoBO1puZEAgN1BFHdzMGqNnrmW3VFO53C4aE2vAKaQG9KOX2kZVs/FKS/68yuN",
+	"j5ERla9usdBSaUKHaVEjvB176H7yhPGjFd9Scv9MbzfNADWZBhnTMEwaqS+OekAjMPpBpBLo/2cFltLI",
+	"rJo9CMpriUTNGA76byRSVVgoGJBFd/ExJIyEqle0JPDfguP8ShGp9XeulZ+kXteyEqT0BsKWmGUkj5ne",
+	"6atD9MOf9n5AHwSfFaRER1aT13wfLPcHH040jZdVQbWw7YzpaMbzlTkd9IBIZoTpxcsO3RvbwACpmNxV",
+	"BWZmO3rlGval1iMz49SQEcerKzPjJEXr01avNTXqxekJEk7+sbqI0TsoMbflfvDtBg2yXU7muC7UaH8E",
+	"wCH5qG2w+Q7NMS1IjnZQ5GSzxGBKIZkiOegz0KoW+iyPD2IMz2FnE6nQ7ZJmS/h4RojW4qqCaLIiOZqt",
+	"2iJ7ECHM9tbiY0XysVbAAdLWYYlKJIiqBQu9tFyZJug7ZNdnlqHPeCwRjrQ9Qxy3Swr4BetFkx95hqZ5",
+	"nDELRPzWHZ9fe+bRfjN40A8sqpJWE3MwdYlJLrlQ4zYly7ossVi1iAYU2i0Y8BBS3dB1m1fCMqKD1poU",
+	"x9G1WHce+ik4/DS5WYyfXWPDysBeY/BMEtY487n+OUjts7y6V2/ZpPS1Vu+G/5S8KeuXMILe2bmzxllG",
+	"KkXyV7QgWs5P6NUXMC001zsALBqWu+ijJPcLtNYla/HQjY304gaA7R+p2pqydOMHuumDhiId226e/Cll",
+	"RPCq89Mng1RnnN/AwZGQEZZgjjPbz08vMtxVBdYnDpyZzgENM7NLXLdIkoZWE4Qrp9lElD3jvCCYGfse",
+	"cNm/apE8tXvseyuze5Oqn6Y95c3r24a0Mw+TyDmRiHFl8bZCuL/DYVbJoGH2gZMLGLEFVaoJxn08QUf+",
+	"d8oGs6R5ThiaC62LdQDaFRExYuQWSUWqCTq+oxL4tP7TdimV7dgYso3JLU9NYYIOki8cVeiVgZHI7EzE",
+	"uEBLfANmyQijfTg3HVPO3hKpVaAU5kvzyvApf1ws+W1DzveivJH1ewRm502npx6fwZRlRa31CSu0G4hg",
+	"JAjQvBPrvrVVOr767KPDtEU6t4bBC0ZVgm8dxa/RmWVa5tSp4ZmXaTcyKTfUA021gGLD3R6UtCioJBln",
+	"uXwwRg+inyVltSLywWAjYTzhJpt7vDeIzW1vov8l9t4t2UaJ73oYHXiDUkbLulzD6t6zYoXszaWeUg+q",
+	"pppFLIiYjtG0IiIjTOEFmY5B1Zk6PE7B0qTXkmEJJ1Z4NY7sJFqHYihGcrQl7EiwOMr+310cw2XPwq7J",
+	"yp6MRoJPEQcCuVYLppYT6Y8yDBNkmq3NeW0VbK+jGxcH63L1wFko0JySIh9EbPZStjvr9+42z13bOpqe",
+	"mo81ZM2vnz5NDVjNn1ew8abRuvSgcoI+wsoFXIVreMp6sSAydO454AQdMC1R718ytIOmBk5X11Rd4YpO",
+	"ju808qnyspqZ6TTZuNVIvhK8NLbbA6UEndWKTIdynVZfg+RSD2BNtw19MeXQfwSe1lom0fDAhpT/Az0w",
+	"gH1gbCu2Q9CFuN4NGikOSUEcA699koOttpAczQUhYG/yjFnTm55F+vjlIidirZ3cEX6foRyMolzS+H4S",
+	"/NjgmNbKryj1cmH+ejSwmAcxfoPIFA5MRozlZpjY1l1qj1EsNhqZDrtSWoYrBXKEUVuN1O9uBRBl86LW",
+	"Oow5S6dmd06duyeW3kYEr73rFOxmzZyUwZ3ZM8CEaFkJfqPlbEnETpDyiLEDyFjf9RcZbp/6n1eOYgMO",
+	"HTzGo8AvR0F0GI1HWv8YjUfXZHUF4NAELwoNUXKnsCBYd29csrjucUlwbrqmSmBlzL+CSMkWO7dcXBvb",
+	"sCALcjdylzM7HnibzYHOLg1c1zb+1PB9JNvF02iu07ISevsQOPk2pcym0y4jd2pj6BdJqp5C0TnOEur4",
+	"gVXCS7xC2ZJzSRrmbfudRA+xABiLldEnHwWBrcCaUrXYZt10Zitr3ASRmDK9QmU8TrrxQs7bx4vGJQEq",
+	"XGKWr8Bd567SswJHXzBQCVJxoYz3jqQlLbAAF4SuiUA/7S55hiV5/j0iLOM5yeHT1jXHix+e7j1NSbk9",
+	"ItrrtQKahSFcuoQbF3MXBEL/3Niz7CWWjI/f0BVGM6I0oGFXGkiCIQeAnPNbpiFk1Q0Zoc65S3nL75XZ",
+	"6xOFxWTxj84R/nzopgDAxeYPR2RrCHC4ucb3dt8dQY66rkf2xHlZYKlOcU5rmRaTnB4/0w2RgJYtL7J2",
+	"DNND2/c+ery3hyzvetShtpLnfTInz73NV2CW85L+Q0uaJ3MkCWh7TQlSde76KppdI+bGdn0ZTqYZBHA2",
+	"2eixxHda0LXdhWFdX+6biJs32LL9PmnBvEnL1ydmWrBcLWn2rc2LvLBQ/3btslIdN5fY6JXVcOOqewzr",
+	"bIvTLcIGBLrFfUpQ8ToTYpcpnJ9/8Nw6ksnPFMH5akZV2t6p+UPNqBZ0gBF0uVpJ1JJv9CU6JTh/rVT1",
+	"1rQGfx29wTsHwEzyolb6rNGSnwF0Y+4wg+CutZt01WqBEsYau6lGTAJ6dtBDDQtsQ+XuzPO3tRm4HRI3",
+	"B1nE/bKNtUzCa5A6cryS3c2jJVnd2c4NFlqqkOBsGa38bXOE+NVZ8ulbP3L89LWdRfzsCGZ0Px4dJwKa",
+	"u1wrHNGZaRaiQOO7buvkEQUKhw+bjhBdE76m+4NbeZBlvGbqJE9P5ODjmcawboJOjnynsGmc91/6Osj7",
+	"jWolRnMNf98e3C7tBUOO9FpYPFjK4AajfqA9M60E11LQdrNM6vmt+LV12AmDdRCwoe8LQTd1fnF6MqT3",
+	"AKAg4/1IVn29ezHwmqwSweQOXHbEYoVmJHgsG1e/NQOvWZYfIlrXLx1YEP1bH1iOryVED/+q5Q/prlSB",
+	"TB6SycJ4SDbPgFg4jD27Hzm3yUPOGPF+zrgonF0cz+fmKJ2t/H3bLjJeAXKwMfS0s8Ku83cqWN/zmbc8",
+	"1yoOdnbqYWENyc/PiLJK1spY+TZFPCR7Ochz+Pqcv6HSd2j9A9ueDn4zlFEPgKyJS4qwsn5bj6xd6ZKh",
+	"pF1pwIKmW3ybXsY00gzTKOjDTQ9YUoEO0ttAFEfYWF08MCINJqXzPZBRMonuseC66WUgEddwbYd4qqWN",
+	"MN6owr2Q6eHR9HR3YmcLMz1IaLjh5LkxaFwpfqVBdeXmvV683i5RR0BHnndzJTRDnL1Z5/N9nxNUjIZY",
+	"Kl5HWT0ENJQ3dDZ3VwwkKhL2+Rzh/0+prsM2GmY5Eijsqq3PfD06k0T9RnTWIZShFJaK2jLMi897OL1M",
+	"s3r5u+H1g87w3oNgLZxTlpae25EuYP+L13C5BFfZ4KEI3+3O6V3jKp+HK2qMrhm/ZWgXgUOzoX4+95cP",
+	"IDyZUH7j6Nzdx9tdo0ZOM8YzsBocPnPTf8kYXNasPwho/2mrrtVE2pZ6Z8g39DxgQj1WOruf7sejN5SR",
+	"wyUWyrhip0BkfLkNlOWS30o42RnRwBaqC2uIpNOjbyC+1tB/tp+ZkCIT50WYokbU2KKjE/tZ6KjHtw6Q",
+	"ol85+JqVWg3xts8N2sLDXDO0Q9mS7lCK80LRast1nJuvomUMOjTcIgYcF4e89IYnM6afQuPkyHg5ka7h",
+	"xA6gSeAKSGCwB7XBQ4TYiKO3CTHBu1MEkyJYIEANjhwrjKyG5S8C+wkXnMnTADZ+5hbC0H+LSkIcW+Gi",
+	"47HKIFZw4yx8HhozgaRrhsqW5lp02x311n66xTZIra+zCyxNI+chVFG7orZr6m0Ln2sdR8ceBm7J/SRi",
+	"8D+QTt4GCA7TM9d08goXxQxn1xu1zDV9/EhWxz/XuJDD9NU1Pb3j6risknrquSND8Iw07Nte0zt6hdcm",
+	"sCgi01bjcAZR6ajDizldSWUA6KbbftiE19afOyBNN9CHR22CrcztuyZIYYMYKOKi6EIRCwJ2F/ORsblo",
+	"0IFLgYFlhxH9mow+iZ0tmP8E1nBlYXLlgDTwTPi03fZt7ZqUX+ZA3NxCLEFDaYziMkgOih2BsVovbpzr",
+	"aBNn10ZD/EJN7+vjsrVhvhyj12R1ZQAxRGkcJAdct5S6LSjAc7tvjXtqXLKJHuz3j23P374cz4yrK1jt",
+	"YHFOA2Eo+oJg3+/x17xwV9wKchCltF6IQjCGBMVyZqU1YoLnsJdH7EvjpE3hXueDF1rAjcYqXxuVm7X2",
+	"AtOifYR25Kd49sc4W9rFJlfgCNu+9IlRv/z4HmogSIpciRwvGqhnBs5JDwBH3UrU4A0biYtN5/kePJhI",
+	"5+Y3ErL0LDuxUBYBEDlpAOaEnTktFBGbBfK2q16L/C0NbJBMA8Vv3iItlbUTBDQXvEyzFYZLa/G02bjA",
+	"BbeRdMUmPwlxXQJVGgpEQnBEWHpsK704SV5rmUHe9fobu+mE9GAdasw4k9SEPHtHyST4o1GTTjTG/0MQ",
+	"ELFKlzTWpsSdrRDRPyEnBZpqAE5N6ic7k8CHZZxQ5D+NZLmJdToN9kpPzSaAmKIddIAkZYvCGwkgUNAG",
+	"eDtNyWRJxsy6tEQH0SaeYefxJVM073cqInZgLDtZ4zaZnK6mkQW9ISxIPEMPlhR0QLX7JTPefCxFxDk2",
+	"W8aSTv9ObW28zTu1aZTpRut5m/lhXyx+lA/MRpRvxLvVtZ03ZJOpARvsSTkQ3DA28rwvOQ4CMGCpiXPB",
+	"oMSYqNPWB3/6N0wQcX7rweDpZ1gwgbQLkR+/ZlR95eHb0aEd4ugnzCadbUOXjuq+3gkSGFRIGtch4nTU",
+	"8UCLU6K7PvMTNs7vsUum9fHbTAz1AAowVvkoniHPSd4QSwYO12PfAkQMwTvgMYV4vtjGVl/whQtWTNxv",
+	"FnxxvlFlcZ8PPZ+CXmPE06my+Yk62o0NsJwOs6L/1lb8X0G344sBGhwfnrPE4XfcDcwPdJQgsrc2Hcww",
+	"SjMyg0Tuq5gntM7HqiKpnCldFSHCEeDQfGl8ztyxye21vo0lds/5HFWC3ECaFO9rm+GikBP0KsTXjiG1",
+	"kj5NTS4Ho2hqgqBs4U/JKaQOmsL3YzcLaFkJvhBENh0fo69ULc1nRhfBeayMhna8Mq0aftpzXMgUFIzP",
+	"olN8wFtd1rOSKkVyv/6Z3nVjn9FytkJTX8lhOkHvi9yU6YDGnQ0ytpHbBc2uNVS5ZXS0JCAx2JmLmqEb",
+	"Sm4n6Jy76CDnug3gYJmFsGUYMHULac9RbBi8m8xSc3e4wgWf5wqLcCXqUQrLS0dU2X7/YGm/H5bmeMJm",
+	"vuZSUG19nRhjfexYTMTpWswsxe76Av3f8MVOMtS/eV3v4zIeukgS47tZ8MWjLhMEAWtAhk0Y9pVpfD8e",
+	"FeTG+TC43D82nZUDa05m9QKi6+DxLRbMZZ1JWm3LsOxkNjxfk2ZIJZnokzNei4wMSaIXN2/Qo1vhwZ+P",
+	"352PNmt+ZiEx0u2jfmy/8mhIezp93pBZYW3cnsFxk2baqd481bi7VD5HjVO5uRRkJ9y/IrmWgOUvoeBB",
+	"6qGD+X1n7imXIZNCtjtlV7LH6rkm1C92VnYOzmXU0MWq600i8MK0b+S2sCGHSK6kIiWakSW+oTZ5nOI+",
+	"i3Sx0lqzUOm4RHM02iTSbnwsCOIzScQNpIqakMm4MTecKa22PDQcz4R0PkKQfE0mI3ksWL6QLH8kq12j",
+	"o1SYNlMABd3WniXA5qmEIKpCa1dzRQT6ICDRManlA2M4gNfNpRlXKWlyJpd4ZUMnY/UZNEss0fTqSv+8",
+	"upr60EzFwRYXBjJJcKhKlvNK5zd4G0YxswBYF4oIhhW9IcXAOUVWT9so9uRczxhbB6ev0RXBHDudsuQ2",
+	"nMCpkLdYeroZWq/ra3DZ9mWdCYtr+WjOC47V8+8TemyoCWZJNeGf+da9SbAqn196IE+Bnu7bffdzlFZS",
+	"6o4pBOpVDMxvDSUsWkmuu1NBzRb9q0501y1S5aIpvmYG52Za7i/NiL1tOrSoLEQ0gU9d+JlKIZuh2Jtj",
+	"+vcWaOlm+q8VbDmcpAZn3V6XFrxTjLI1QgtMymSwm0PWGZat4psckybB43tGQKUm+X+ic3xNJHKhnl6t",
+	"N7wWUu883tsrbZrpx3ty2gL25WX+3x8y+c9S/lP+s/zn8p/5ozTwW9Taccb6ihS5BSojAowKeXx4f6aF",
+	"6g8X+t+j4zfH58dJBSHhzT00SivtDr7Jz21A3pzR/afuzJINk2nbFHau5dZ0ZevAmPSTJi4cYdeHu050",
+	"puZrskrXJfUf+BRILcNX/6zO22PqQSCrXiASX+2m7SBvpM8FhpvQfHuP8DCvT6ZYl11dn+GvkXHch/5i",
+	"55K/hFt3ocXIHFW+N3fT6i0YxnaohU9X5dckt+PMWR3KVDBOc3YmCvb3YOQIcNts5girGGzoSCz8U6Pg",
+	"WBNpiZOzWR2te20ZZ+IYkoADDBLE5YHepraUtzoM1Sbl9lVJrM9AM75n6zgYOfqimp3jkQyOMGsLdNlm",
+	"baT31fXs1I/7iqj8NXCi19lKQBEdSX8+TleTSoQZd6tY0zyVjxwdnhyddkoBuchsY9U2vDekzoK4VW/F",
+	"YUTdcnHdEgke/rS38+LT58fjp/eXl5NHn5/ehwcPd93vJ/eP/jNZvogN8p6pBLdZuo99MuxXXIRkzbtg",
+	"7VtoFbOqRcUlMSkNkkprxYV6i+96MtGYjClIN3I5UhzUXDo3wxBr6b12SJhXlBdm//mzZ0+fQeYL8/de",
+	"KtcAzIay9bkYf7XZ1KJIz+Ti9M0abGyUwG1+MJOrDEg0rDxgJLXP48qFf/Dq3xuvTqFLkfc3RJzTkmwX",
+	"R2f0Fj5H/EaTOS0TnuVDw+AS0+iGwvlAyC17eqO/C90MAnWiG3j0LxeYl1jIbxGc15jGZkETcHSlCesK",
+	"bImp09Xyvi0XfyEiUvDWxC07AZ8s183AeMFQFMhhLi6DHsqudrbjsF37W7rhGg9cwW83euG2YNV2KNq8",
+	"rmHAiHf8V4ZEMuj61wJGvK5hkIiZ1ld3rHMJlMxJgBVEh7mD4BcvNp76sMVucHD9Wsv14aNfecEb/SbX",
+	"srOvTOcXp28m6OOSMIRvMC00sY8RVSjDtZbWsQuYJYvS+TPVgiHKQAtZrioiCsqu04BZA4SwoGEAiFlx",
+	"BwRLmvelXOGQxxku82jzms1VvPCbt3GCG21sXhfmPtVnk1YCM1lATQezHRqeVRIJUpAbzPpiNNZAJF5h",
+	"D0zqr6xSQ0ErkizCEZJ7gSyjaYYyA8iKF0WqnhDCEhVcU5UtlaV71jABTzG4xGbc1kIyyTCTDlJ/qAHf",
+	"xGQTcP3Jlnf/Q3vbGm3bokBDui/kzJbN8u6WDc+XjuKwNgV112c6+GG1DwVJboigagVuKIUPLDWTiAX2",
+	"yEMrWYIwmRHUrvaN7vvEdBA/+ug6uzep0fuy0BhP9hQcoolGqtOzx0822qn1cM5DLT6gLX4SLNfcevTM",
+	"0VjlwN8GbkA4+NCYhDhefjYuQXoVmVZyVmsuXdZ6efnb8I2V7DszldHNj/Spuw3lAFhToTh2dTadevMe",
+	"KSwGdbrHgkR1yV2F+yh0olGjyZ+8LqmpK9mHW1k6u242g8xaEWw/9aK3UfE5UYU4Kp7g6lpi8NKSbu+0",
+	"DbQ+7bNdVs7ZA2UqMeBOY1ue2Epmxp2MG2fpRF74ZK7w9cXjOl9ApRkpKVuArX7N+uO048H83Fi1v6y+",
+	"OEF0rs93cF3R57snHpsq1BSV/Q49sDR4hYviATrwN5rBauLzaM9WfvzoO8YZeeCdAB+hd3xIDw3O5icA",
+	"nqih24Fc7m0KfiemnwPodF2LdzDQ/Xj0c41B53X3B0kkvOa3qAT9w64xeILHqwwQBjlS7qNLhr5DU3KH",
+	"M1WsrjiDeMpj8ydcYlpSLGup4t5MIHPkT6hhOse00AguOaQlwCzuAYQ5+7EZFRcFRG8WRScpeiMdkRmr",
+	"puYh1JeDUME4uXqUAd4Z0js7zozK7CIt0U9sNU6T3sRfqtgQCKhP5nvspl1vzOzLZhWRXIQGzZiARrYg",
+	"uL90KcVi8j10mHhv6DDxwpOfTFaq/7L69K5IyV+c41pfBGX7Msuwi1pvluBm8kDa5wVmixoc2zma1wIS",
+	"0jAsBL+VUDrCdmSq8TnERfEz+wjfyolNi/0fl6PLETp4dwQP/8EZmdDcPNSfAGmnj8PmZMaoKqAUunPX",
+	"jeed86z2R9j+JUNoqVQl93d3c57JyAKa8XK3lmTHP9mFUXbcKC3b8N6TZI7OVtn+TpEeC2+w75qoSOsE",
+	"7pkIh2LUcEk1QSZVhy3JQ/OpPZfsUT11ZaPP/bCnthCyd1E9ctLBj3TA/VM0/0gkax/Mm89uR4ldZWZt",
+	"ocE3nC2ISNyw2u5Q1LwVl2UKvBTYxVjaLx5Id9M5GYTAYYVZjKIAbQfdGfyc3oXnqdtkf147P5hNe7G5",
+	"wTSFD9pjl+x3uMku2QAs9SSoNEDuJ1tPk8PJVyZlUOGiIrAxwLkcNJCcFIeisV661PvJV/4yaE1Ing2h",
+	"3gD/4gRx0UH3cUjirgVU22F3t8hWiXjXsNbqUWvw4Tnc+6B6vxHwKffrc1qSQ86U4EV/TSm9SkLhsJkB",
+	"kE0hdYUZgXjNG8KUq04EcYYEAjCNqXXJpRpDaTmDnButa8sKMzC4wh0qZqhmIZWTc/w0G0stuQwV85f4",
+	"xthpXaMxutUqGDBtpqhmUjOibqHiOYO4gqJYucndYgpRpyZDbU6qgq+cGXdOGZVLU/WR3K3/Eko3hQkr",
+	"WhpDIJZyDKZBwYsiWols2hEi4Nm6anow3cSOm7z3O+8GEbTsu/Dc6yOuedqA22hii6MLSm70ySd4acJl",
+	"TcY7E30DWlyoeExNvUCbbm3qCxtMUctSivO/a4G6OZ7Znlp3mksCgb5ZbYzIvjSxsCcpyjVOzQVxyFxp",
+	"3RkfyHA7Ya8jgoRpZ7QJrh/JbMn59dqCU1BK1HqdGhqwYoMilZygl3ENKu/4UlUFbfAcUxNJRVI1whLd",
+	"Eg0lCeBwYqGRppGsZzY1d8uh3TnLdGKymSlPipHJzWzFeCxtV928aV0typWaSNcciUpLrRk9Ugy+2sCC",
+	"5OBSvV2ecxOmAAhw91ma52CtxNQVES18mDIhfiZN2Xn6+XKkR8OKi8vRProcHbw7uhyN0WWYndQvfvp8",
+	"ObomK9PGXi8RMdGscFfrMOabZlfHf7k4eHNm3hgPZujpcpTz7JqInZzIa8Wry9Gn+0/309Qhuk74PW/I",
+	"vZZAo5oiwTxjOF47V5HfTVdhOf7XdP1tl91gdpfYLZaYv213rI+T/nBw78kMx45ZDFzO2fxQdjBjLlWC",
+	"LhbgZY1e1UqLCP7zGyKkr5hINcvO66yR1sQOsKqIHCPJQ8VGH8XACwKpmGpmsp0bvDW5kDNTT0K5HVuD",
+	"l+SjcbpBJghe87oSZF7QxVL1fu/vNnoazMHY2fcWri7WzA6zjKz5XDPFHZAANrTZOE1otX6u0GTDhM1g",
+	"g2Z9TasK2lzTopC3VGXLCWELvGg/zKl0zz91SR1oGLk0HpvtGTHpH/vZ+YuX04hgNjQ99KSzoeGHiIg2",
+	"9RnhaUPTVw5ZG9ode4xtGjugbUPLM0WqM091AxpvsSzdfOjSdNvBy4N5bLdET6Jx4x89ZR57ak2/P4oI",
+	"N2K6boj3N0QImjvVq13PuSUWucZWISOCRAWLKatqZb2zTYa95KUdJFqxGZclvoE7GJ8mxrfPiaQLqARH",
+	"Vsb7wB4/IThXwskuaJ4TFtJeecdwUTP0f/7X/4ZbCzwrSNDwbboUI+3ChZhEDwm7oYKzEnQbScQNzcg4",
+	"mtEYaY0srwvyyE/fms7zCTrykBtrUCg9a2wy2Aoy10o/n6OCllSZ+swaTO7oyjiTdUmE/Hc4myALQckN",
+	"YLRklz7IulJitIKeMmqhge46hC5FcI8L62nNheDc11uLPg9yXfd+1qJulMxBbHHxC2Ln/+rx6ZN3A31E",
+	"ruYxGaRocIIOudHKHCXhQMkFVSAvrv4d5SuGS5qhhzYNJLnTOoGG/qP4w5A+UnY95+yFrROzbE9PIRKL",
+	"SzUxTkoM9clf0Ej/M01cCCakLr+zUdjaa4SvLtPZVFkQtPzOBk+UarAn05oQfK+ZphM5YIlsJ8ND7+0H",
+	"Lzc6KVgAXEgivL+C//yvFPcUmdDvwehjJM2WPAq7J7EU60VsTqtYXjz4cDIajw7f6H8v9D9nh6+Pjy7e",
+	"HA+8GGmz80M//4OKjsZr3h8W699frH99ZpkhHCqa/n8BouHz4SjeyOe6XrwPLy5Ojh6lGNkAPui27tMn",
+	"e3sv5s/Jznz+Ym/n+x/ws50/5Rjv/Glv/v1s9gMmz148nn5Jbc0LM99WeU2jtrk1yNYENQsrZ5RhfydN",
+	"cAnfwfnK9NkkCAZbtrEKuGUcHL3debJpnn81h0yiHmabz7vzyIKxlfnUzn9lU4ZJb6yLFitqJtM2gOWq",
+	"0oe0pD01wcN7r+Te4ILmONJymyyqs+RURdguPgKt0jyBmI3nTXJ16SCzd1GAWVzhlCONzWIVQErTK+Kx",
+	"RDcsA0C/UGhi5NtS4d1OeKZPOmlJwx8RXk7EwhqQrWjYywM01f7+xbzzL5LrrEXW16HbSsqD2xcD4Tap",
+	"nMJz/T2Y4XphazRqMN8aPSVJN94nsznIYcP5vUuYfhjHXw5Pjw/Oj4+mYzQ9vXj37uTdn/XPVwcnb8zD",
+	"49PT96fm5+H7tx/eHNvGhwfvDo91m57ZkaqHC8CrIAxG4iu4WxUFKfTapclJQboS6+C7mH6hSWtqKXc0",
+	"zZWHFKYE7s1vvc1yLddKSn0eIUGQ20rsgxWknDQVqVp1sI2k60oWYNY4lozPCZTm8JUDjR0yp7rnUp9Z",
+	"XMTub5IIigv6D5Kj/3H2/t0EHUTWdpRhIVYu9Ook16SCrRstg7+MHV7/MhZRvyQ5BbYyVVzhwlhED3nN",
+	"1HSCzszOd8dFZzTLGU5y20VoJ6cT9BFT1Wjv3eMzXpacxfVKUVBuYM28Vr4CL+guNjOovwhpQ6PrMpn1",
+	"1RffcG1x0ZGLGnXeu1gG/Ghmq0g13E4slVaSrrKqTm/lgL2tV/CjTeWnltE+xx1vo4Pz84PDH7Vg/foY",
+	"/vvm/cHR1fkxZFR5f/76+HQ0Hr08ODs53E7MPvAzP4BK3EFCDm8OlyT94g3H+TmRKvXuvT5PUi9eYkkz",
+	"kLGzWipevkn7SxzCSxulhaWWy8x1pCmC3hbZjPMGJMbVkKSQ2dX7NlqEpyXEgZJ+UxECHrKllL9GMGsT",
+	"sJ1wU97yo3i8dvEcUqnVNc0nWkmIn+/QsuLCRAhAWqjRgqplPQO3igXni4Ls6g+BI9MF44K8wrSoRdIb",
+	"iShT+KhxetqbBX1C79rIkLIkOcWKFKvoZHdL1A2laSnT+XWbacSGX5ydgT3cSVWRn3L3yIeZNCoBOebw",
+	"+XLk7sDNLdfjPXk5up8mfZkhZUpGpOTiZDiySQvXhmtpaZTkXhgHfuU4K50jCnwNkkpRIe0KwJBRYEZ+",
+	"C3IRg9yXE3fV28iDqV24rVToDsIBvFr2HKprTh77yW+BAXdj9UXM7BbL2JwzjKUNl7Dddu+Iqm6jDZes",
+	"0wkyW4LS1gfxG1tJy92jR9J3Zd2deXzHb7Rx739pNSKox6W1IWMdCJTrvCUEYQ9UiMxEWMVeBZnxxIkL",
+	"gG8rytsQl5Tk3hIatwbRu7ZLdQCSh4rGrx6nQUOUqeffJy0GkRT6i7ajw57zsrL54JtyvaHCdB/fTGMa",
+	"qNog+LpfvwnXX/1eK7H3gN7O3nfAxCxdg9879LEjiHFWsp5vABmfWG2NS6e9eEO7KFwfxx0nIlzCbd0Q",
+	"c2rUF6whfD6cK4VvXq7S/pdxziOojHW75FAHIFpVazaTTSMdmdC9L7PS/xIQbQ2fLwXONpD5GmBJbJ1o",
+	"G/TvlQ94VXCcp00U1nUFzXi+QtIaIo0q4jeP95OZoJdEgtlvCjvFqd+0JNMxIlHojZMpdatI6AyaMpjL",
+	"gJXto6nn7lPga9OkP8d3U9OdHKNp8NuwX0SOHL7dN9DMoeOhLNG7PYHhPbp8+zJ+2uhGs8eUyDaM97Ee",
+	"EIPLjINfmw2CIpn3yOjWjTcME00gEXXB5zGVGEOLi8FoTsfkgv21RcfrxvEyAF/RRrTpwfsyKjn+heP8",
+	"s8YzTSNqTsVw3tVO9Xxjy1W5TEMtbuEYQT+r6AsIPvBxNt6C1CsFep/9TbHAiVhMG1uj5ZQQc+tEFTOF",
+	"sY9zC4UTosY+diBkpfNkeAAGWWucx1LyjMKp7+tWAnZcqIG9ATejfpnYGeXL7cqf6duhk44GFSYwNKtq",
+	"lOvKwexbuYBagtlEUevyAbMo6+7Da7LaCXUTHgXX1oCtRiRIb1XotcZ4P+B4IDUAl9JywBpk3KTLoZ+3",
+	"S1z7wTdHj7VrdCeBjwJw+9EQCxLdOAOboMHItTjcUYG445Nd2ossd6xUhpskDskS04QJ81g/RjjPwSwZ",
+	"CVST4Qk6j0y2BNSWydL5NmmmakEuUqklo7SS+vsHcHk3pwVB9qt07UIrDg4TFMc+YKVlF/GRXpspwI+Y",
+	"QL8eE63J7hCyIA7LF57K2bYpV3golbOpZasA1MYk5O2Eyhtn0qzhmEj+3sz+aP0Y2vWAYrcFSB8DBdZs",
+	"TZbGTRjoACbIiOQTdMA0e7lkCO100ggmIDtNt/Tw7HnfhGJPozbs+sZqQmwaJbX3MLe/1hZbdxWc/wBr",
+	"H1iHSQ4e5k0sdKP87iGzFfgewOUVBCaZLD67f5ccirdBcpv9z6OCZoRJEnKYaiY02h+9PTkfOS4LfzRy",
+	"d7lqCD6dETJ+bDfOa2j0eLI32QNvlIowXNHR/ujp5PFkz2RpXsrRPquLAo6GvM7652lPE4COF0127FMQ",
+	"1rns8QLrFm0Ilfu9EPjwhmI0PSNKQUHJnct6b+8pQSdMkYUrR+EeWsYqp48gKQoxflZQ4OHD+7NzryuD",
+	"B7TVkaNiEoSRGyJ8ZapmXItEPMtq4cIPU/4Vtuyi1qOspVh0DBwmnMlaE3Yja9Ala8bS3JkMLpit0PTJ",
+	"3d3U5TKDWkxYIpxdM35bkHxB/LV+CNEDawCVyNx55RNkAxakNchqMQG27pzeaLU54yyX6KG/MpoVxHnn",
+	"+ClJmpNHDedwE6Go534CLqdLKDUpSSZMzo1+Wd6FpRp8ZFgIreNrvfZvO2cvd87ogmF9ik9dnCHwphDv",
+	"o+nEOvPcEEHnq7i/BxLhWi31ZsmoWk1QqBZerMYAUot80/m6iRprMJQvtrqKHWTSrMejz+Y11l66JXzA",
+	"/zmo7Utyt2PKcOXo9duDw52z1wdPnj1H0sHJiS0C3zYsQmPIc1d7sdvWCXWjmqmMW/VcpssSZztyifUQ",
+	"sLUyPYGcLohUZqtNJz6Htw++EsSOZaRtPzWoZmHqkCJqfcyo9Ij1GGzgDMJwR/sj0ypwuiZ5jGJhC5L4",
+	"jUeGHYMca8IEdS/Rgp7g71/88Hxv78UPmLx48vT5k2fz7188yZ49m82zOSZ47/vs2eNstvf0afZ0ls0J",
+	"fvH9ixfz53/64Rn50/Nnj7NmGvu455/2dl7gnfmnz8+/v0+Vt/lkZkukesnzXvfn0IQSr46eRt+BhGn2",
+	"OXDdJ3/7W0orW6End3dNrhFYhtTYIrRSDUPfBiZiLuWcEhKdMta5wc5Vn2/3/zcAAP//",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,

--- a/openapi/spec.yml
+++ b/openapi/spec.yml
@@ -9,6 +9,40 @@ consumes:
   - application/json
 produces:
   - application/json
+webhooks:
+  steadybit-webhook:
+    post:
+      summary: Steadybit Custom Webhook
+      description: >-
+        The Steadybit platform can be configured (via `Settings -> Integrations -> Webhooks`) to send
+        an HTTP POST request to a custom endpoint whenever certain platform events occur, e.g.,
+        experiment executions changing state or the kill switch being engaged/disengaged.
+
+        The platform expects any `2xx` status code as acknowledgement. The response body is ignored.
+        Requests time out after five seconds (configurable on the platform side) and are not retried.
+
+        If a shared secret is configured for the webhook, the request carries an `X-SB-Signature`
+        header that endpoints can use to verify the request's authenticity. Additionally, any custom
+        headers configured for the webhook are added to the request.
+      parameters:
+        - name: X-SB-Signature
+          in: header
+          required: false
+          description: >-
+            Only present if a shared secret is configured for the webhook. Contains the
+            hex-encoded HMAC-SHA256 signature of the raw request body, computed with the
+            configured secret, in the format `hmac-sha256 <hex-digest>`. Endpoints should
+            recompute the signature and compare it to this header to verify authenticity.
+          schema:
+            type: string
+            pattern: '^hmac-sha256 [0-9a-f]{64}$'
+            example: 'hmac-sha256 2a49760097ae923625f492c55bfcfaea04c51cb033c3bcfea9499f6875e8651c'
+      requestBody:
+        $ref: '#/components/requestBodies/WebhookRequestBody'
+      responses:
+        '2XX':
+          description: >-
+            Any 2xx status code acknowledges receipt of the event. The response body is ignored.
 components:
   schemas:
     ActionList:
@@ -1293,6 +1327,363 @@ components:
               description: >-
                 At what frequency should the state endpoint be called? Takes
                 durations in the format of `100ms` or `10s`.
+    WebhookEventType:
+      title: Webhook Event Type
+      type: string
+      description: >-
+        The platform event that caused the webhook to be triggered. Future platform versions may
+        introduce additional event types, so endpoints should tolerate unknown values.
+      enum:
+        - experiment.execution.requested
+        - experiment.execution.created
+        - experiment.execution.preflight
+        - experiment.execution.completed
+        - experiment.execution.failed
+        - experiment.execution.errored
+        - experiment.execution.canceled
+        - experiment.execution.step-started
+        - experiment.execution.step-completed
+        - experiment.execution.step-failed
+        - experiment.execution.step-errored
+        - experiment.execution.step-canceled
+        - experiment.execution.step-skipped
+        - killswitch.engaged
+        - killswitch.disengaged
+      x-enum-varnames:
+        - WebhookEventExperimentExecutionRequested
+        - WebhookEventExperimentExecutionCreated
+        - WebhookEventExperimentExecutionPreflight
+        - WebhookEventExperimentExecutionCompleted
+        - WebhookEventExperimentExecutionFailed
+        - WebhookEventExperimentExecutionErrored
+        - WebhookEventExperimentExecutionCanceled
+        - WebhookEventExperimentExecutionStepStarted
+        - WebhookEventExperimentExecutionStepCompleted
+        - WebhookEventExperimentExecutionStepFailed
+        - WebhookEventExperimentExecutionStepErrored
+        - WebhookEventExperimentExecutionStepCanceled
+        - WebhookEventExperimentExecutionStepSkipped
+        - WebhookEventKillswitchEngaged
+        - WebhookEventKillswitchDisengaged
+    WebhookPayload:
+      title: Webhook Payload
+      description: >-
+        The request body sent to custom webhook endpoints. Besides `event` and `time`, exactly one
+        of the event-specific properties is present: `execution` for `experiment.execution.*`
+        events, `killswitch` for `killswitch.*` events. Properties without a value are omitted
+        from the serialized JSON.
+      type: object
+      properties:
+        event:
+          $ref: '#/components/schemas/WebhookEventType'
+        time:
+          type: string
+          format: date-time
+          description: The timestamp at which the event was fired.
+        killswitch:
+          $ref: '#/components/schemas/WebhookKillswitch'
+        execution:
+          $ref: '#/components/schemas/WebhookExperimentExecution'
+        executionStepId:
+          type: string
+          format: string
+          x-go-type: uuid.UUID
+          x-go-type-import:
+            path: github.com/google/uuid
+          description: >-
+            In case the webhook was triggered by an `experiment.execution.step-*` event, this
+            contains the id of the step execution having triggered the webhook. Matches the `id`
+            of one of the steps within `execution.steps`.
+      required:
+        - event
+        - time
+    WebhookUserSummary:
+      title: Webhook User Summary
+      description: Summary about a platform user referenced in a webhook payload.
+      type: object
+      properties:
+        username:
+          type: string
+          description: Username of the user, internal identifier of Steadybit.
+        name:
+          type: string
+          description: Display name of the user.
+        email:
+          type: string
+          description: Email address of the user.
+        pictureUrl:
+          type: string
+          description: URL of the user's profile picture.
+      required:
+        - username
+    WebhookKillswitch:
+      title: Webhook Killswitch
+      description: >-
+        In case the webhook was triggered by a kill switch-related event, this contains more
+        information about the engaged / disengaged kill switch.
+      type: object
+      properties:
+        engagedBy:
+          type: string
+          description: Username of the user who has engaged the kill switch.
+        engagedByDetails:
+          $ref: '#/components/schemas/WebhookUserSummary'
+        engaged:
+          type: string
+          format: date-time
+          description: Timestamp when the kill switch was engaged.
+        disengagedBy:
+          type: string
+          description: Username of the user who has disengaged the kill switch.
+        disengagedByDetails:
+          $ref: '#/components/schemas/WebhookUserSummary'
+        disengaged:
+          type: string
+          format: date-time
+          description: Timestamp when the kill switch was disengaged.
+    WebhookExperimentExecution:
+      title: Webhook Experiment Execution
+      description: The execution of a single experiment.
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Unique experiment execution id that identifies this specific experiment execution.
+        experimentKey:
+          type: string
+          description: Unique experiment key that identifies the experiment. Combination of team key and an increasing number, e.g. `ADM-2`.
+        teamKey:
+          type: string
+          description: The key of the team owning the experiment.
+        environment:
+          type: string
+          description: The unique identifier (UUID) of the environment in which the experiment is executed, e.g. `32009f6e-ff90-47a5-8daa-80f4bb7ae591`.
+        name:
+          type: string
+          description: Name of the experiment to easily identify it.
+        hypothesis:
+          type: string
+          description: The hypothesis that is validated by the experiment.
+        created:
+          type: string
+          format: date-time
+          description: Timestamp when the experiment execution was created.
+        createdBy:
+          $ref: '#/components/schemas/WebhookUserSummary'
+        createdVia:
+          type: string
+          description: The creation trigger that caused this experiment execution to be started.
+          enum:
+            - API
+            - CLI
+            - UI
+            - SCHEDULE
+          x-enum-varnames:
+            - WebhookExecutionCreatedViaApi
+            - WebhookExecutionCreatedViaCli
+            - WebhookExecutionCreatedViaUi
+            - WebhookExecutionCreatedViaSchedule
+        experimentVersion:
+          type: integer
+          description: Experiment design version which can be used to identify changes between experiment runs.
+        ended:
+          type: string
+          format: date-time
+          description: Timestamp when the experiment execution ended.
+        state:
+          type: string
+          description: Current state of the experiment execution, e.g. `CREATED`, `RUNNING`, `FAILED`, `ERRORED`, `COMPLETED`, `CANCELED`.
+        steps:
+          type: array
+          description: The steps that are executed in parallel or sequence in the experiment.
+          items:
+            $ref: '#/components/schemas/WebhookExperimentExecutionStep'
+        overrides:
+          allOf:
+            - $ref: '#/components/schemas/WebhookExecutionOverrides'
+          deprecated: true
+          x-deprecated-reason: >-
+            Execution overrides are an input to the experiment execution and only contain the
+            values overridden for this specific run — variables defined on the other levels
+            (environment, service, experiment, schedule) are not included. They are therefore
+            of limited use to webhook consumers. This property may be removed in a future
+            platform version.
+        reason:
+          type: string
+          description: Reason in case the experiment execution failed or errored.
+    WebhookExperimentExecutionStep:
+      title: Webhook Experiment Execution Step
+      description: >-
+        A step that is executed as part of an experiment. There is no explicit type discriminator
+        within the serialized JSON. Action steps carry `actionId`, `actionKind`, `radius`,
+        `targetExecutions` and `totalTargetCount`. Service validation steps carry `serviceId` and
+        `validations`. Wait steps carry only the common properties. Properties without a value are
+        omitted from the serialized JSON.
+      type: object
+      properties:
+        id:
+          type: string
+          format: string
+          x-go-type: uuid.UUID
+          x-go-type-import:
+            path: github.com/google/uuid
+          description: Unique identifier of this step execution.
+        predecessorId:
+          type: string
+          format: string
+          x-go-type: uuid.UUID
+          x-go-type-import:
+            path: github.com/google/uuid
+          description: >-
+            Unique identifier of the step execution that precedes this step, omitted if it is the
+            first step of a lane.
+        state:
+          type: string
+          description: Current state of this step in the experiment, e.g. `RUNNING`, `FAILED`, `ERRORED`, `COMPLETED`.
+        started:
+          type: string
+          format: date-time
+          description: Timestamp when this experiment step was started.
+        ended:
+          type: string
+          format: date-time
+          description: Timestamp when this experiment step ended.
+        reason:
+          type: string
+          description: Reason in case this experiment step execution failed or errored.
+        ignoreFailure:
+          type: boolean
+          description: Whether the experiment should fail/error immediately in case this step fails/errors.
+        parameters:
+          type: object
+          additionalProperties: true
+          description: >-
+            Step-specific parameters of the experiment step configuration, e.g. `{"duration": "10s"}`.
+        customLabel:
+          type: string
+          description: Custom label assigned during experiment design to express the intention of this step.
+        actionId:
+          type: string
+          description: Only present for action steps. Unique identifier of the action that is executed in this step, e.g. `com.steadybit.extension_container.stress_cpu`.
+        actionKind:
+          type: string
+          description: Only present for action steps. Kind of the executed action.
+          enum:
+            - ATTACK
+            - CHECK
+            - LOAD_TEST
+            - OTHER
+            - BASIC
+          x-enum-varnames:
+            - WebhookActionKindAttack
+            - WebhookActionKindCheck
+            - WebhookActionKindLoadTest
+            - WebhookActionKindOther
+            - WebhookActionKindBasic
+        radius:
+          $ref: '#/components/schemas/WebhookBlastRadius'
+        targetExecutions:
+          type: array
+          description: >-
+            Only present for action steps. List of targets that are expected to be affected by this
+            action. This list may change in case targets aren't available at the specific time of
+            execution.
+          items:
+            $ref: '#/components/schemas/WebhookTarget'
+        totalTargetCount:
+          type: integer
+          format: int64
+          description: Only present for action steps. Number of targets that are affected in total.
+        serviceId:
+          type: string
+          format: string
+          x-go-type: uuid.UUID
+          x-go-type-import:
+            path: github.com/google/uuid
+          description: Only present for service validation steps. Unique identifier of the service.
+        validations:
+          type: array
+          description: Only present for service validation steps. List of actions performed as part of this service validation step.
+          items:
+            $ref: '#/components/schemas/WebhookExperimentExecutionStep'
+    WebhookBlastRadius:
+      title: Webhook Blast Radius
+      description: >-
+        Only present for action steps. Blast radius that is applied to define the set of targets as
+        well as an optional random subset.
+      type: object
+      properties:
+        targetType:
+          type: string
+          description: Target type that is affected by the action, e.g. `com.steadybit.extension_container.container`.
+        percentage:
+          type: integer
+          description: In case a percentage subset of the specified targets should be affected.
+        maximum:
+          type: integer
+          description: In case a fixed number as subset of the specified targets should be affected.
+        predicate:
+          type: object
+          additionalProperties: true
+          description: >-
+            Query defining the overall superset of targets being affected. For example:
+            `{"operator": "AND", "predicates": [{"key": "container.host/name", "operator": "EQUALS", "values": ["docker-desktop"]}]}`
+    WebhookTarget:
+      title: Webhook Target
+      description: A target that is expected to be affected by an action.
+      type: object
+      properties:
+        type:
+          type: string
+          description: Type of the target, e.g. `com.steadybit.extension_container.container`.
+        name:
+          type: string
+          description: Identifier of the target.
+        attributes:
+          type: array
+          description: >-
+            The discovered attributes of this target, restricted to the attributes configured for
+            the webhook. A key may be associated multiple times with a single target.
+          items:
+            $ref: '#/components/schemas/WebhookTargetAttribute'
+    WebhookTargetAttribute:
+      title: Webhook Target Attribute
+      description: An attribute (key-value pair) that is associated with a target.
+      type: object
+      properties:
+        key:
+          type: string
+          description: The key of the attribute, may be associated multiple times with the same target.
+        value:
+          type: string
+          description: The value of the attribute.
+      required:
+        - key
+        - value
+    WebhookExecutionOverrides:
+      title: Webhook Execution Overrides
+      description: >-
+        Overrides that were passed as input to a single experiment execution and are not saved
+        into the experiment design. They only contain the values overridden for this specific
+        run — variables defined on the other levels (environment, service, experiment, schedule)
+        are not included. Deprecated, as they are therefore of limited use to webhook consumers;
+        may be removed in a future platform version.
+      deprecated: true
+      type: object
+      properties:
+        environment:
+          type: string
+          description: >-
+            The environment in which the experiment is executed instead of the environment
+            specified in the experiment design.
+        variables:
+          type: object
+          additionalProperties:
+            type: string
+          description: >-
+            Variables that are only used for this specific experiment execution. Constant values
+            are passed literally; dynamic (select expression) values are rendered as a
+            human-readable summary, e.g. `select 3 of host.name on com.steadybit.extension_host.host`.
   requestBodies:
     QueryMetricsRequestBody:
       title: Query Metrics Request
@@ -1416,6 +1807,15 @@ components:
             required:
               - executionId
               - state
+    WebhookRequestBody:
+      title: Webhook Request
+      description: >-
+        The HTTP request payload sent to custom webhook endpoints whenever a subscribed platform
+        event occurs.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/WebhookPayload'
   responses:
     ActionListResponse:
       title: Action List Response


### PR DESCRIPTION
## Summary

The platform's custom webhook integration sends HTTP POST requests to user-provided endpoints, but the request structure was undocumented. This PR adds it to the ActionKit OpenAPI spec so endpoint implementers can build against a documented contract.
