### PR TITLE
fix(stress): count CPUs across all words of Cpus_allowed mask

### DIFF
--- a/go/action_kit_commons/CHANGELOG.md
+++ b/go/action_kit_commons/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.8.1
+
+- stress: fix `ReadCpusAllowedCount` to count CPUs across all words of the
+  `Cpus_allowed` mask. On hosts with more than 32 CPUs the kernel prints the
+  mask as comma-separated 32-bit hex words, so the previous single-word parse
+  capped the detected CPU count at 32 (causing stress-cpu with "all cores" to
+  use only 32 workers).
+
 ## 1.8.0
 
 - netfault: use `tc qdisc replace` (instead of `add`) for the root qdisc in

--- a/go/action_kit_commons/utils/cpus_allowed.go
+++ b/go/action_kit_commons/utils/cpus_allowed.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math/bits"
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -21,15 +22,25 @@ func ReadCpusAllowedCount(fname string) (int, error) {
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		l := scanner.Text()
-		if strings.HasPrefix(l, "Cpus_allowed:") {
-			var bitmask uint = 0
-			if _, err := fmt.Sscanf(l, "Cpus_allowed: %x", &bitmask); err == nil {
-				return bits.OnesCount(bitmask), nil
-			} else {
-				return -1, err
-			}
+		if value, ok := strings.CutPrefix(l, "Cpus_allowed:"); ok {
+			return countCpusAllowed(value)
 		}
 	}
 
 	return -1, fmt.Errorf("failed to read Cpus_allowed")
+}
+
+// countCpusAllowed counts the set bits of the Cpus_allowed mask. The kernel
+// prints the mask as a comma-separated list of 32-bit hex words for hosts with
+// more than 32 CPUs, e.g. "ffffffff,ffffffff,ffffffff,ffffffff" for 128 CPUs.
+func countCpusAllowed(value string) (int, error) {
+	count := 0
+	for _, word := range strings.Split(strings.TrimSpace(value), ",") {
+		bitmask, err := strconv.ParseUint(strings.TrimSpace(word), 16, 32)
+		if err != nil {
+			return -1, err
+		}
+		count += bits.OnesCount64(bitmask)
+	}
+	return count, nil
 }

--- a/go/action_kit_commons/utils/cpus_allowed_test.go
+++ b/go/action_kit_commons/utils/cpus_allowed_test.go
@@ -22,6 +22,9 @@ func Test_readCpusAllowedCount(t *testing.T) {
 		{name: "parse error", status: "Cpus_allowed: invalid", want: -1, wantErr: assert.Error},
 		{name: "four cpus", status: "Cpus_allowed:   f\n", want: 4, wantErr: assert.NoError},
 		{name: "two cpus", status: "Cpus_allowed:   6", want: 2, wantErr: assert.NoError},
+		{name: "32 cpus", status: "Cpus_allowed:\tffffffff\n", want: 32, wantErr: assert.NoError},
+		{name: "128 cpus", status: "Cpus_allowed:\tffffffff,ffffffff,ffffffff,ffffffff\n", want: 128, wantErr: assert.NoError},
+		{name: "48 cpus", status: "Cpus_allowed:\t0000ffff,ffffffff\n", want: 48, wantErr: assert.NoError},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Problem

The stress-cpu attack with **"All cores"** (`workers: 0`) was effectively capped at **32 workers** on hosts with more than 32 vCPUs (observed on a 128-vCPU host running `--cpu 32`).

Root cause is in `utils.ReadCpusAllowedCount`, used by extensions to resolve `workers=0` into the actual core count. The kernel prints the `Cpus_allowed` mask in `/proc/<pid>/status` as a **comma-separated list of 32-bit hex words** for hosts with >32 CPUs, e.g. for 128 cores:

```
Cpus_allowed:	ffffffff,ffffffff,ffffffff,ffffffff
```

The old code used `fmt.Sscanf(l, "Cpus_allowed: %x", &bitmask)`, which stops at the first non-hex char (the comma) and therefore only counted the first word → max 32. Partially-filled top words under-reported further (e.g. 48 cores → 16).

## Fix

Split the mask on commas and sum the set bits across all words.

## Tests

Added cases for 32, 48 (`0000ffff,ffffffff`) and 128 (`ffffffff,ffffffff,ffffffff,ffffffff`) CPUs. All pass.