### PR TITLE
feat(netfault)!: remove SetSnapshotRestore — snapshot follows strict flag

### DIFF
--- a/go/action_kit_commons/CHANGELOG.md
+++ b/go/action_kit_commons/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **Breaking:** `netfault.SetSnapshotRestore` is removed. The snapshot/restore path now runs whenever strict mode is OFF (i.e. `SetStrictRootQdisc(false)`), and is implicitly disabled when strict mode is ON because preflight already refuses non-`noqueue` roots. Callers should drop their `SetSnapshotRestore(...)` call; the behaviour is now driven entirely by `SetStrictRootQdisc`.
+
 ## 1.8.2
 
 - netfault: opt-in qdisc snapshot/restore. With `SetSnapshotRestore(true)` (env var `STEADYBIT_EXTENSION_NETWORK_SNAPSHOT_RESTORE=true`), Apply captures the root qdisc tree (qdiscs + filters, incl. tuned `fq` params) of every target interface via RTNETLINK and Revert replays it after the attack's `tc del`. Preserves cloud-tuned roots (e.g. GKE's `mq + fq` with `buckets=32768 horizon=2s`) that previously reset to kernel defaults and degraded the host until reboot. Off by default; Linux only.

--- a/go/action_kit_commons/network/netfault/netfault.go
+++ b/go/action_kit_commons/network/netfault/netfault.go
@@ -165,11 +165,14 @@ func generateAndRunCommands(ctx context.Context, runner CommandRunner, opts Opts
 			return err
 		}
 		// Snapshot the root qdisc tree before installing the attack so we can
-		// restore it on revert. Only the first attack per netns takes the
-		// snapshot (loadSnapshot returns ok=true once one is stored).
-		// Failures are logged but do not block the attack — the experiment
-		// must still execute even if snapshot is unavailable.
-		if snapshotEnabled {
+		// restore it on revert. Only runs when strict mode is OFF — with
+		// strict mode ON the preflight already refused non-`noqueue` roots,
+		// and on a `noqueue` root there's nothing to preserve. Only the first
+		// attack per netns takes the snapshot (loadSnapshot returns ok=true
+		// once one is stored). Failures are logged but do not block the
+		// attack — the experiment must still execute even if snapshot is
+		// unavailable.
+		if !strictRootQdisc {
 			if _, exists := loadSnapshot(netNsID); !exists {
 				if p, ok := opts.(tcCommandProvider); ok {
 					if ifs := p.tcRootQdiscInterfaces(); len(ifs) > 0 {
@@ -268,11 +271,11 @@ func generateAndRunCommands(ctx context.Context, runner CommandRunner, opts Opts
 	if mode == modeDelete {
 		popActiveNetfault(netNsID, opts)
 		// After the last attack on this netns is reverted, restore the saved
-		// qdisc tree (if any). The snapshot only exists when snapshotEnabled
-		// was true at apply time and the apply succeeded. On restore failure
-		// keep the snapshot so a manual retry (e.g. operator re-runs revert)
-		// has another chance; only delete on success.
-		if snapshotEnabled && !hasActiveNetfault(netNsID) {
+		// qdisc tree (if any). A snapshot only exists when strict mode was
+		// OFF at apply time and the apply succeeded. On restore failure keep
+		// the snapshot so a manual retry (e.g. operator re-runs revert) has
+		// another chance; only delete on success.
+		if !strictRootQdisc && !hasActiveNetfault(netNsID) {
 			if snap, ok := loadSnapshot(netNsID); ok {
 				if rerr := applyRestore(runner, snap); rerr != nil {
 					log.Warn().Err(rerr).Str("netNs", netNsID).Msg("qdisc restore failed; snapshot retained for retry")

--- a/go/action_kit_commons/network/netfault/snapshot.go
+++ b/go/action_kit_commons/network/netfault/snapshot.go
@@ -10,24 +10,17 @@ import (
 	"github.com/florianl/go-tc"
 )
 
-// snapshotEnabled is the package-level feature flag for the qdisc snapshot/
-// restore behaviour. Off by default so the change is opt-in for the first
-// release.
-var snapshotEnabled bool
-
-// SetSnapshotRestore toggles the qdisc snapshot+restore behaviour. When
-// enabled, Apply captures the root qdisc tree for every interface the attack
-// touches and Revert replays it after the attack's tc del. This preserves
-// cloud-tuned root qdiscs (e.g. GKE's `mq + fq` with buckets=32768 horizon=2s)
-// that would otherwise revert to kernel defaults after `tc qdisc del root`.
+// Snapshot/restore is no longer a separate toggle: it runs whenever strict
+// mode is OFF, i.e. when the operator has chosen to let network attacks
+// install on non-`noqueue` roots. With strict on, the preflight refuses the
+// attack before snapshot would matter. With strict off, snapshot is what
+// keeps the cloud-tuned root from getting reset to kernel defaults on
+// revert. There's no third state worth supporting (strict=off +
+// snapshot=off was the clobber-no-restore behaviour we retired), so we
+// drive both off the single `strictRootQdisc` knob.
 //
-// Disabled by default. Operators can enable it via the extension config (e.g.
-// STEADYBIT_EXTENSION_NETWORK_SNAPSHOT_RESTORE=true in extension-container).
-//
-// Snapshot/restore uses RTNETLINK (github.com/florianl/go-tc) and only takes
-// effect on Linux. On non-Linux builds the feature flag is accepted but the
-// snapshot is a no-op.
-func SetSnapshotRestore(enabled bool) { snapshotEnabled = enabled }
+// Snapshot/restore uses RTNETLINK (github.com/florianl/go-tc) and only
+// takes effect on Linux. On non-Linux builds the path is a no-op.
 
 // interfaceSnapshot holds the qdisc and filter state for one interface within
 // a single network namespace.

--- a/go/action_kit_commons/network/netfault/snapshot_test.go
+++ b/go/action_kit_commons/network/netfault/snapshot_test.go
@@ -124,11 +124,3 @@ func TestSnapshotStore_OverwriteSameNetNs(t *testing.T) {
 	assert.Contains(t, got.Interfaces, "eth1")
 }
 
-func TestSetSnapshotRestore_TogglesFlag(t *testing.T) {
-	t.Cleanup(func() { SetSnapshotRestore(false) })
-
-	SetSnapshotRestore(true)
-	assert.True(t, snapshotEnabled)
-	SetSnapshotRestore(false)
-	assert.False(t, snapshotEnabled)
-}


### PR DESCRIPTION
## Summary

Cleanup. Removes the now-redundant `SetSnapshotRestore` API from action-kit-commons. The snapshot/restore path runs whenever strict mode is OFF (`SetStrictRootQdisc(false)`); it's implicitly inactive when strict mode is ON because preflight refuses the attack before snapshot would matter.

## Why

When v1.8.2 introduced snapshot/restore (PR #453), it had a separate opt-in toggle. After validation, both consuming extensions collapsed their config to a single env var (`STEADYBIT_EXTENSION_NETWORK_STRICT_ROOT_QDISC`) and now call `SetSnapshotRestore(!cfg.NetworkStrictRootQdisc)` — i.e. the snapshot flag is the exact inverse of strict, no information of its own.

This PR makes that linkage internal to the library.

## Versioning

Technically a breaking API change, but **no customer release shipped v1.8.2**: both extension-host and extension-container have it pinned in `main` but haven't cut a release yet. So in practice there are no external consumers to migrate. I'd suggest tagging this as `v1.8.3` (or `v1.9.0` if you prefer a minor bump) and treating the SetSnapshotRestore-era as effectively pre-release.

## Change

- `snapshot.go`: drop the `snapshotEnabled` variable and `SetSnapshotRestore` function.
- `netfault.go`: replace `if snapshotEnabled` (two sites) with `if !strictRootQdisc`.
- `snapshot_test.go`: drop `TestSetSnapshotRestore_TogglesFlag`.
- `CHANGELOG.md`: Unreleased entry.

## Follow-up

Two small extension PRs to drop the now-dangling `netfault.SetSnapshotRestore(...)` line from each `main.go`. I'll open both pinned to this PR's HEAD; they can merge after this lands and a release tag is cut.

## Test plan

- [x] 141 tests pass on darwin
- [x] `GOOS=linux go vet ./...` clean
- [ ] CI on Linux