### PR TITLE
feat(netfault)!: move qdisc snapshot into caller-owned state

### DIFF
--- a/go/action_kit_commons/CHANGELOG.md
+++ b/go/action_kit_commons/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.10.0
+
+- **Breaking:** netfault snapshot now lives in caller-owned state, not a process-local map.
+  `netfault.Apply` returns `(QdiscSnapshot, error)`; `netfault.Revert` takes the snapshot as a
+  fourth argument. Types `QdiscSnapshot` and `InterfaceSnapshot` are exported and JSON-serializable
+  so callers can persist them in their action's per-execution state. The in-memory `snapshotStore`
+  is removed. This makes the snapshot survive extension restarts mid-attack (state lives on the
+  Steadybit platform, not the extension pod) and removes the cross-attack store coordination that
+  was already redundant given `activeNetfault` serializes attacks per netns. `tc.Object` JSON
+  roundtrip is verified by a new regression test (`TestQdiscSnapshotJSONRoundtrip`) covering mq,
+  tuned fq (BucketsLog/Horizon), prio, htb, clsact, ingress, pfifo_fast, noqueue, and filters.
+
 ## 1.9.0
 
 - **Breaking:** `netfault.SetSnapshotRestore` is removed. The snapshot/restore path now runs whenever strict mode is OFF (i.e. `SetStrictRootQdisc(false)`), and is implicitly disabled when strict mode is ON because preflight already refuses non-`noqueue` roots. Callers should drop their `SetSnapshotRestore(...)` call; the behaviour is now driven entirely by `SetStrictRootQdisc`.

--- a/go/action_kit_commons/network/netfault/netfault.go
+++ b/go/action_kit_commons/network/netfault/netfault.go
@@ -46,9 +46,23 @@ type CommandRunner interface {
 	netNsPath() string
 }
 
-// Apply installs the attack.
-func Apply(ctx context.Context, runner CommandRunner, opts Opts) error {
-	return generateAndRunCommands(ctx, runner, opts, modeAdd)
+// Apply installs the attack and returns a QdiscSnapshot describing the
+// pre-attack qdisc tree. The caller is expected to persist the snapshot in
+// the action's per-execution state (action_kit_sdk JSON state) and pass it
+// back to Revert.
+//
+// The returned snapshot is empty (QdiscSnapshot.IsEmpty() == true) when:
+//   - strict-root-qdisc mode is on (preflight refused non-`noqueue` roots —
+//     there's nothing to preserve),
+//   - the opts do not implement tcCommandProvider (no tc root touched),
+//   - the snapshot capture itself errored (logged; attack still proceeds).
+//
+// On Apply failure the returned snapshot is empty even when capture
+// succeeded: the snapshot would describe a state the attack never fully
+// replaced, and replaying it from Revert would clobber a partial attack
+// install with the original tree. Drop it instead.
+func Apply(ctx context.Context, runner CommandRunner, opts Opts) (QdiscSnapshot, error) {
+	return generateAndRunCommands(ctx, runner, opts, modeAdd, QdiscSnapshot{})
 }
 
 // ErrUserRootQdisc reports that a target interface already carries a
@@ -113,28 +127,44 @@ func hasActiveNetfault(netNsId string) bool {
 	return len(activeNetfault[netNsId]) > 0
 }
 
-func Revert(ctx context.Context, runner CommandRunner, opts Opts) error {
-	return generateAndRunCommands(ctx, runner, opts, modeDelete)
+// Revert removes the attack and replays the snapshot (if non-empty) onto
+// the netns root qdisc tree. `snap` should be the value Apply returned for
+// the same opts; pass a zero QdiscSnapshot to skip the restore step (used
+// by callers that don't care about preserving the pre-attack tree, e.g.
+// iptables-only attacks).
+func Revert(ctx context.Context, runner CommandRunner, opts Opts, snap QdiscSnapshot) error {
+	_, err := generateAndRunCommands(ctx, runner, opts, modeDelete, snap)
+	return err
 }
 
-func generateAndRunCommands(ctx context.Context, runner CommandRunner, opts Opts, mode mode) error {
+// generateAndRunCommands is the shared body for Apply (modeAdd) and Revert
+// (modeDelete). On Add it captures a snapshot before running the attack
+// commands and returns it to the caller; on Delete it consumes the snapshot
+// from the caller and replays it after running the cleanup commands.
+//
+// The `incoming` snapshot is meaningful on Delete only — Apply ignores it.
+// The returned snapshot is meaningful on Add only — Delete always returns an
+// empty one. Splitting Apply/Revert into separate exported functions keeps
+// the public API typed (Apply returns a snapshot, Revert doesn't) without
+// the shared body needing a sum type.
+func generateAndRunCommands(ctx context.Context, runner CommandRunner, opts Opts, mode mode, incoming QdiscSnapshot) (QdiscSnapshot, error) {
 	var ipCommandsV4, ipCommandsV6, tcCommands []string
 	var err error
 
 	if p, ok := opts.(ipCommandProvider); ok {
 		if ipCommandsV4, err = p.ipCommands(familyV4, mode); err != nil {
-			return err
+			return QdiscSnapshot{}, err
 		}
 		if ipv6Supported() {
 			if ipCommandsV6, err = p.ipCommands(familyV6, mode); err != nil {
-				return err
+				return QdiscSnapshot{}, err
 			}
 		}
 	}
 
 	if p, ok := opts.(tcCommandProvider); ok {
 		if tcCommands, err = p.tcCommands(mode); err != nil {
-			return err
+			return QdiscSnapshot{}, err
 		}
 	}
 
@@ -154,33 +184,25 @@ func generateAndRunCommands(ctx context.Context, runner CommandRunner, opts Opts
 	runLock.LockKey(netNsID)
 	defer func() { _ = runLock.UnlockKey(netNsID) }()
 
-	// snapshotTakenHere records whether this invocation took the qdisc
-	// snapshot (vs reusing one a previous attack had already stored). Used to
-	// roll back the snapshot if the attack's tc commands fail — otherwise the
-	// snapshot would persist describing a state that was never fully installed,
-	// and a later revert would replay it against a partial attack.
-	var snapshotTakenHere bool
+	var snapshot QdiscSnapshot
 	if mode == modeAdd {
 		if err := pushActiveNetfault(netNsID, opts); err != nil {
-			return err
+			return QdiscSnapshot{}, err
 		}
-		// Snapshot the root qdisc tree before installing the attack so we can
-		// restore it on revert. Only runs when strict mode is OFF — with
-		// strict mode ON the preflight already refused non-`noqueue` roots,
-		// and on a `noqueue` root there's nothing to preserve. Only the first
-		// attack per netns takes the snapshot (loadSnapshot returns ok=true
-		// once one is stored). Failures are logged but do not block the
-		// attack — the experiment must still execute even if snapshot is
-		// unavailable.
+		// Snapshot the root qdisc tree before installing the attack so the
+		// caller can hand it back to Revert. Skipped when strict mode is ON
+		// (preflight already refused non-`noqueue` roots, nothing to
+		// preserve) and when opts doesn't touch a tc root (e.g. iptables-only
+		// attacks). Capture failures are logged but do not block the attack —
+		// the experiment must still execute even if snapshot is unavailable.
 		if !strictRootQdisc {
-			if _, exists := loadSnapshot(netNsID); !exists {
-				if p, ok := opts.(tcCommandProvider); ok {
-					if ifs := p.tcRootQdiscInterfaces(); len(ifs) > 0 {
-						if serr := captureSnapshot(runner, netNsID, ifs); serr != nil {
-							log.Warn().Err(serr).Str("netNs", netNsID).Msg("qdisc snapshot failed; revert will not restore prior state")
-						} else {
-							snapshotTakenHere = true
-						}
+			if p, ok := opts.(tcCommandProvider); ok {
+				if ifs := p.tcRootQdiscInterfaces(); len(ifs) > 0 {
+					snap, serr := captureSnapshot(runner, netNsID, ifs)
+					if serr != nil {
+						log.Warn().Err(serr).Str("netNs", netNsID).Msg("qdisc snapshot failed; revert will not restore prior state")
+					} else {
+						snapshot = snap
 					}
 				}
 			}
@@ -203,7 +225,7 @@ func generateAndRunCommands(ctx context.Context, runner CommandRunner, opts Opts
 	if provider, ok := opts.(iptablesScriptProvider); ok {
 		v4, v6, scriptErr := provider.iptablesScripts(mode)
 		if scriptErr != nil {
-			return scriptErr
+			return QdiscSnapshot{}, scriptErr
 		}
 
 		if log.Debug().Enabled() {
@@ -263,56 +285,49 @@ func generateAndRunCommands(ctx context.Context, runner CommandRunner, opts Opts
 	// the original tree against a partially-installed attack. Better to leave
 	// the host with the kernel's default-restore path than with a stale
 	// snapshot we can't trust.
-	if mode == modeAdd && err != nil && snapshotTakenHere {
-		deleteSnapshot(netNsID)
+	if mode == modeAdd && err != nil && !snapshot.IsEmpty() {
 		log.Warn().Str("netNs", netNsID).Msg("dropped qdisc snapshot because apply errored; revert will fall back to kernel-default restore")
+		snapshot = QdiscSnapshot{}
 	}
 
 	if mode == modeDelete {
 		popActiveNetfault(netNsID, opts)
-		// After the last attack on this netns is reverted, restore the saved
-		// qdisc tree (if any). A snapshot only exists when strict mode was
-		// OFF at apply time and the apply succeeded. On restore failure keep
-		// the snapshot so a manual retry (e.g. operator re-runs revert) has
-		// another chance; only delete on success.
-		if !strictRootQdisc && !hasActiveNetfault(netNsID) {
-			if snap, ok := loadSnapshot(netNsID); ok {
-				if rerr := applyRestore(runner, snap); rerr != nil {
-					log.Warn().Err(rerr).Str("netNs", netNsID).Msg("qdisc restore failed; snapshot retained for retry")
-					err = errors.Join(err, rerr)
-				} else {
-					// applyRestore logs the verified post-restore state itself.
-					deleteSnapshot(netNsID)
-				}
+		// Replay the caller-provided snapshot (if any) after the attack's
+		// tc-del has run. Strict-mode check guards against a caller passing
+		// in a snapshot from a mode flip — there's no scenario where Revert
+		// should replay a snapshot when strict mode is on at revert time.
+		if !strictRootQdisc && !incoming.IsEmpty() {
+			if rerr := applyRestore(runner, incoming); rerr != nil {
+				log.Warn().Err(rerr).Str("netNs", netNsID).Msg("qdisc restore failed")
+				err = errors.Join(err, rerr)
 			}
 		}
 	}
 
-	return err
+	return snapshot, err
 }
 
-// captureSnapshot opens the runner's netns and stores the qdisc snapshot.
+// captureSnapshot opens the runner's netns and returns the qdisc snapshot.
 // Wrapped in its own function so the netns-fd open/close is one place.
 // Logs the rendered snapshot at INFO level so operators investigating a
 // restore failure can see exactly what was captured.
-func captureSnapshot(runner CommandRunner, netNsID string, interfaces []string) error {
+func captureSnapshot(runner CommandRunner, netNsID string, interfaces []string) (QdiscSnapshot, error) {
 	path := runner.netNsPath()
 	f, err := openNetNs(path)
 	if err != nil {
-		return err
+		return QdiscSnapshot{}, err
 	}
 	defer func() { _ = f.Close() }()
 	snap, err := takeSnapshot(int(f.Fd()), netNsID, interfaces)
 	if err != nil {
-		return err
+		return QdiscSnapshot{}, err
 	}
-	storeSnapshot(snap)
 	log.Info().
 		Str("netNs", netNsID).
 		Int("interfaces", len(snap.Interfaces)).
 		Str("snapshot", renderSnapshot(snap)).
 		Msg("captured qdisc snapshot")
-	return nil
+	return snap, nil
 }
 
 // applyRestore opens the runner's netns, replays the saved snapshot, then
@@ -320,7 +335,7 @@ func captureSnapshot(runner CommandRunner, netNsID string, interfaces []string) 
 // restore. The post-restore snapshot is logged at INFO so the operator can
 // see whether the kernel accepted the replay byte-for-byte. Any structural
 // divergence (missing qdisc, extra qdisc, wrong parent) is logged at WARN.
-func applyRestore(runner CommandRunner, snap qdiscSnapshot) error {
+func applyRestore(runner CommandRunner, snap QdiscSnapshot) error {
 	path := runner.netNsPath()
 	f, err := openNetNs(path)
 	if err != nil {
@@ -375,7 +390,7 @@ func applyRestore(runner CommandRunner, snap qdiscSnapshot) error {
 
 // snapshotInterfaceNames returns the sorted set of interface names in the
 // snapshot. Used to re-snapshot for post-restore verification.
-func snapshotInterfaceNames(snap qdiscSnapshot) []string {
+func snapshotInterfaceNames(snap QdiscSnapshot) []string {
 	out := make([]string, 0, len(snap.Interfaces))
 	for name := range snap.Interfaces {
 		out = append(out, name)

--- a/go/action_kit_commons/network/netfault/netfault.go
+++ b/go/action_kit_commons/network/netfault/netfault.go
@@ -148,37 +148,11 @@ func Revert(ctx context.Context, runner CommandRunner, opts Opts, snap QdiscSnap
 // the public API typed (Apply returns a snapshot, Revert doesn't) without
 // the shared body needing a sum type.
 func generateAndRunCommands(ctx context.Context, runner CommandRunner, opts Opts, mode mode, incoming QdiscSnapshot) (QdiscSnapshot, error) {
-	var ipCommandsV4, ipCommandsV6, tcCommands []string
-	var err error
-
-	if p, ok := opts.(ipCommandProvider); ok {
-		if ipCommandsV4, err = p.ipCommands(familyV4, mode); err != nil {
-			return QdiscSnapshot{}, err
-		}
-		if ipv6Supported() {
-			if ipCommandsV6, err = p.ipCommands(familyV6, mode); err != nil {
-				return QdiscSnapshot{}, err
-			}
-		}
+	ipCommandsV4, ipCommandsV6, tcCommands, err := generateCommands(opts, mode)
+	if err != nil {
+		return QdiscSnapshot{}, err
 	}
-
-	if p, ok := opts.(tcCommandProvider); ok {
-		if tcCommands, err = p.tcCommands(mode); err != nil {
-			return QdiscSnapshot{}, err
-		}
-	}
-
-	if log.Debug().Enabled() {
-		if len(ipCommandsV4) > 0 {
-			log.Debug().Str("mode", string(mode)).Strs("ip_cmds_v4", ipCommandsV4).Msg("prepared ip batch commands (IPv4)")
-		}
-		if len(ipCommandsV6) > 0 {
-			log.Debug().Str("mode", string(mode)).Strs("ip_cmds_v6", ipCommandsV6).Msg("prepared ip batch commands (IPv6)")
-		}
-		if len(tcCommands) > 0 {
-			log.Debug().Str("mode", string(mode)).Strs("tc_cmds", tcCommands).Msg("prepared tc batch commands")
-		}
-	}
+	logPreparedCommands(mode, ipCommandsV4, ipCommandsV6, tcCommands)
 
 	netNsID := runner.id()
 	runLock.LockKey(netNsID)
@@ -189,96 +163,17 @@ func generateAndRunCommands(ctx context.Context, runner CommandRunner, opts Opts
 		if err := pushActiveNetfault(netNsID, opts); err != nil {
 			return QdiscSnapshot{}, err
 		}
-		// Snapshot the root qdisc tree before installing the attack so the
-		// caller can hand it back to Revert. Skipped when strict mode is ON
-		// (preflight already refused non-`noqueue` roots, nothing to
-		// preserve) and when opts doesn't touch a tc root (e.g. iptables-only
-		// attacks). Capture failures are logged but do not block the attack —
-		// the experiment must still execute even if snapshot is unavailable.
-		if !strictRootQdisc {
-			if p, ok := opts.(tcCommandProvider); ok {
-				if ifs := p.tcRootQdiscInterfaces(); len(ifs) > 0 {
-					snap, serr := captureSnapshot(runner, netNsID, ifs)
-					if serr != nil {
-						log.Warn().Err(serr).Str("netNs", netNsID).Msg("qdisc snapshot failed; revert will not restore prior state")
-					} else {
-						snapshot = snap
-					}
-				}
-			}
-		}
+		snapshot = captureSnapshotForApply(runner, netNsID, opts)
 	}
 
-	if len(ipCommandsV4) > 0 {
-		logCurrentIpRules(ctx, runner, familyV4, "before")
-	}
+	logBeforeAfterRules(ctx, runner, ipCommandsV4, ipCommandsV6, tcCommands, "before")
 
-	if len(ipCommandsV6) > 0 {
-		logCurrentIpRules(ctx, runner, familyV6, "before")
+	if scriptErr := runIptablesScripts(ctx, runner, opts, mode, &err); scriptErr != nil {
+		return QdiscSnapshot{}, scriptErr
 	}
+	runBatchCommands(ctx, runner, mode, ipCommandsV4, ipCommandsV6, tcCommands, &err)
 
-	if len(tcCommands) > 0 {
-		logCurrentTcRules(ctx, runner, "before")
-	}
-
-	// If opts provide iptables scripts, execute them first
-	if provider, ok := opts.(iptablesScriptProvider); ok {
-		v4, v6, scriptErr := provider.iptablesScripts(mode)
-		if scriptErr != nil {
-			return QdiscSnapshot{}, scriptErr
-		}
-
-		if log.Debug().Enabled() {
-			if len(v4) > 0 {
-				log.Debug().Str("mode", string(mode)).Str("iptables_v4", strings.Join(v4, "\n")).Msg("prepared iptables-restore script (IPv4)")
-			}
-			if len(v6) > 0 {
-				log.Debug().Str("mode", string(mode)).Str("iptables_v6", strings.Join(v6, "\n")).Msg("prepared ip6tables-restore script (IPv6)")
-			}
-		}
-		if len(v4) > 0 {
-			if _, restoreErr := runner.run(ctx, []string{"iptables-restore", "-w", "-n"}, v4); restoreErr != nil {
-				log.Warn().Err(restoreErr).Str("mode", string(mode)).Msg("iptables-restore failed")
-				err = errors.Join(err, restoreErr)
-			}
-		}
-		if ipv6Supported() && len(v6) > 0 {
-			if _, restoreErr := runner.run(ctx, []string{"ip6tables-restore", "-w", "-n"}, v6); restoreErr != nil {
-				log.Warn().Err(restoreErr).Str("mode", string(mode)).Msg("ip6tables-restore failed")
-				err = errors.Join(err, restoreErr)
-			}
-		}
-	}
-
-	if len(ipCommandsV4) > 0 {
-		if _, ipErr := executeIpCommands(ctx, runner, ipCommandsV4, "-family", string(familyV4)); ipErr != nil {
-			err = errors.Join(err, filterBatchErrors(ipErr, mode, ipCommandsV4))
-		}
-	}
-
-	if len(ipCommandsV6) > 0 {
-		if _, ipErr := executeIpCommands(ctx, runner, ipCommandsV6, "-family", string(familyV6)); ipErr != nil {
-			err = errors.Join(err, filterBatchErrors(ipErr, mode, ipCommandsV6))
-		}
-	}
-
-	if len(tcCommands) > 0 {
-		if _, tcErr := executeTcCommands(ctx, runner, tcCommands); tcErr != nil {
-			err = errors.Join(err, filterBatchErrors(tcErr, mode, tcCommands))
-		}
-	}
-
-	if len(ipCommandsV4) > 0 {
-		logCurrentIpRules(ctx, runner, familyV4, "after")
-	}
-
-	if len(ipCommandsV6) > 0 {
-		logCurrentIpRules(ctx, runner, familyV6, "after")
-	}
-
-	if len(tcCommands) > 0 {
-		logCurrentTcRules(ctx, runner, "after")
-	}
+	logBeforeAfterRules(ctx, runner, ipCommandsV4, ipCommandsV6, tcCommands, "after")
 
 	// If apply failed after taking a snapshot, drop it: the snapshot describes
 	// a state the attack never fully replaced, so a later revert would replay
@@ -305,6 +200,151 @@ func generateAndRunCommands(ctx context.Context, runner CommandRunner, opts Opts
 	}
 
 	return snapshot, err
+}
+
+// generateCommands invokes the opt-in command providers and returns the
+// prepared ip / tc batch command strings. Any provider error short-circuits
+// and is returned to the caller.
+func generateCommands(opts Opts, mode mode) (ipV4, ipV6, tcCmds []string, err error) {
+	if p, ok := opts.(ipCommandProvider); ok {
+		if ipV4, err = p.ipCommands(familyV4, mode); err != nil {
+			return nil, nil, nil, err
+		}
+		if ipv6Supported() {
+			if ipV6, err = p.ipCommands(familyV6, mode); err != nil {
+				return nil, nil, nil, err
+			}
+		}
+	}
+	if p, ok := opts.(tcCommandProvider); ok {
+		if tcCmds, err = p.tcCommands(mode); err != nil {
+			return nil, nil, nil, err
+		}
+	}
+	return ipV4, ipV6, tcCmds, nil
+}
+
+// logPreparedCommands emits the prepared batch commands at DEBUG level so
+// operators reproducing an attack can see exactly what would be applied.
+// No-op when DEBUG is not enabled.
+func logPreparedCommands(mode mode, ipV4, ipV6, tcCmds []string) {
+	if !log.Debug().Enabled() {
+		return
+	}
+	if len(ipV4) > 0 {
+		log.Debug().Str("mode", string(mode)).Strs("ip_cmds_v4", ipV4).Msg("prepared ip batch commands (IPv4)")
+	}
+	if len(ipV6) > 0 {
+		log.Debug().Str("mode", string(mode)).Strs("ip_cmds_v6", ipV6).Msg("prepared ip batch commands (IPv6)")
+	}
+	if len(tcCmds) > 0 {
+		log.Debug().Str("mode", string(mode)).Strs("tc_cmds", tcCmds).Msg("prepared tc batch commands")
+	}
+}
+
+// captureSnapshotForApply returns the qdisc snapshot for the given runner +
+// opts, or an empty snapshot when capture is not applicable (strict mode on,
+// no tc root touched) or fails (logged). The empty-snapshot fallback keeps
+// the attack running even when snapshot is unavailable — the experiment
+// always proceeds, only revert behaviour degrades.
+func captureSnapshotForApply(runner CommandRunner, netNsID string, opts Opts) QdiscSnapshot {
+	if strictRootQdisc {
+		return QdiscSnapshot{}
+	}
+	p, ok := opts.(tcCommandProvider)
+	if !ok {
+		return QdiscSnapshot{}
+	}
+	ifs := p.tcRootQdiscInterfaces()
+	if len(ifs) == 0 {
+		return QdiscSnapshot{}
+	}
+	snap, err := captureSnapshot(runner, netNsID, ifs)
+	if err != nil {
+		log.Warn().Err(err).Str("netNs", netNsID).Msg("qdisc snapshot failed; revert will not restore prior state")
+		return QdiscSnapshot{}
+	}
+	return snap
+}
+
+// logBeforeAfterRules emits the current ip/tc state at TRACE level around
+// the batch execution. Either skipped or unfolded into the three protocol
+// calls.
+func logBeforeAfterRules(ctx context.Context, runner CommandRunner, ipV4, ipV6, tcCmds []string, when string) {
+	if len(ipV4) > 0 {
+		logCurrentIpRules(ctx, runner, familyV4, when)
+	}
+	if len(ipV6) > 0 {
+		logCurrentIpRules(ctx, runner, familyV6, when)
+	}
+	if len(tcCmds) > 0 {
+		logCurrentTcRules(ctx, runner, when)
+	}
+}
+
+// runIptablesScripts loads the caller's iptables-restore scripts and pipes
+// them through iptables-restore / ip6tables-restore. iptables errors are
+// joined into *outErr (non-fatal for the attack lifecycle); only a
+// scriptErr from the provider itself short-circuits the caller.
+func runIptablesScripts(ctx context.Context, runner CommandRunner, opts Opts, mode mode, outErr *error) error {
+	provider, ok := opts.(iptablesScriptProvider)
+	if !ok {
+		return nil
+	}
+	v4, v6, scriptErr := provider.iptablesScripts(mode)
+	if scriptErr != nil {
+		return scriptErr
+	}
+	logIptablesScripts(mode, v4, v6)
+	if len(v4) > 0 {
+		if _, restoreErr := runner.run(ctx, []string{"iptables-restore", "-w", "-n"}, v4); restoreErr != nil {
+			log.Warn().Err(restoreErr).Str("mode", string(mode)).Msg("iptables-restore failed")
+			*outErr = errors.Join(*outErr, restoreErr)
+		}
+	}
+	if ipv6Supported() && len(v6) > 0 {
+		if _, restoreErr := runner.run(ctx, []string{"ip6tables-restore", "-w", "-n"}, v6); restoreErr != nil {
+			log.Warn().Err(restoreErr).Str("mode", string(mode)).Msg("ip6tables-restore failed")
+			*outErr = errors.Join(*outErr, restoreErr)
+		}
+	}
+	return nil
+}
+
+// logIptablesScripts emits the prepared iptables-restore scripts at DEBUG
+// level. Separate from logPreparedCommands because the iptables scripts are
+// multi-line strings rather than command slices.
+func logIptablesScripts(mode mode, v4, v6 []string) {
+	if !log.Debug().Enabled() {
+		return
+	}
+	if len(v4) > 0 {
+		log.Debug().Str("mode", string(mode)).Str("iptables_v4", strings.Join(v4, "\n")).Msg("prepared iptables-restore script (IPv4)")
+	}
+	if len(v6) > 0 {
+		log.Debug().Str("mode", string(mode)).Str("iptables_v6", strings.Join(v6, "\n")).Msg("prepared ip6tables-restore script (IPv6)")
+	}
+}
+
+// runBatchCommands executes the prepared ip/tc batch commands. Errors are
+// joined into *outErr — the caller decides whether to escalate after the
+// whole batch has run.
+func runBatchCommands(ctx context.Context, runner CommandRunner, mode mode, ipV4, ipV6, tcCmds []string, outErr *error) {
+	if len(ipV4) > 0 {
+		if _, ipErr := executeIpCommands(ctx, runner, ipV4, "-family", string(familyV4)); ipErr != nil {
+			*outErr = errors.Join(*outErr, filterBatchErrors(ipErr, mode, ipV4))
+		}
+	}
+	if len(ipV6) > 0 {
+		if _, ipErr := executeIpCommands(ctx, runner, ipV6, "-family", string(familyV6)); ipErr != nil {
+			*outErr = errors.Join(*outErr, filterBatchErrors(ipErr, mode, ipV6))
+		}
+	}
+	if len(tcCmds) > 0 {
+		if _, tcErr := executeTcCommands(ctx, runner, tcCmds); tcErr != nil {
+			*outErr = errors.Join(*outErr, filterBatchErrors(tcErr, mode, tcCmds))
+		}
+	}
 }
 
 // captureSnapshot opens the runner's netns and returns the qdisc snapshot.

--- a/go/action_kit_commons/network/netfault/netfault.go
+++ b/go/action_kit_commons/network/netfault/netfault.go
@@ -20,6 +20,10 @@ import (
 
 const maxTcCommands = 2048
 
+// ipFamilyFlag is the `ip` CLI option that selects the address family
+// (inet/inet6) for `ip rule` and `ip -batch` calls.
+const ipFamilyFlag = "-family"
+
 var (
 	ipPath = utils.LocateExecutable("ip", "STEADYBIT_EXTENSION_IP_PATH")
 
@@ -331,12 +335,12 @@ func logIptablesScripts(mode mode, v4, v6 []string) {
 // whole batch has run.
 func runBatchCommands(ctx context.Context, runner CommandRunner, mode mode, ipV4, ipV6, tcCmds []string, outErr *error) {
 	if len(ipV4) > 0 {
-		if _, ipErr := executeIpCommands(ctx, runner, ipV4, "-family", string(familyV4)); ipErr != nil {
+		if _, ipErr := executeIpCommands(ctx, runner, ipV4, ipFamilyFlag, string(familyV4)); ipErr != nil {
 			*outErr = errors.Join(*outErr, filterBatchErrors(ipErr, mode, ipV4))
 		}
 	}
 	if len(ipV6) > 0 {
-		if _, ipErr := executeIpCommands(ctx, runner, ipV6, "-family", string(familyV6)); ipErr != nil {
+		if _, ipErr := executeIpCommands(ctx, runner, ipV6, ipFamilyFlag, string(familyV6)); ipErr != nil {
 			*outErr = errors.Join(*outErr, filterBatchErrors(ipErr, mode, ipV6))
 		}
 	}
@@ -443,7 +447,7 @@ func logCurrentIpRules(ctx context.Context, runner CommandRunner, family family,
 		return
 	}
 
-	stdout, err := executeIpCommands(ctx, runner, []string{"rule show"}, "-family", string(family))
+	stdout, err := executeIpCommands(ctx, runner, []string{"rule show"}, ipFamilyFlag, string(family))
 	if err != nil {
 		log.Trace().Err(err).Msg("failed to get current ip rules")
 		return
@@ -495,7 +499,7 @@ func defaultIpv6Supported() bool {
 	// execute the following command to check if ipv6 is disabled:
 	// ip -family inet6 rule
 	// if the command fails, we assume that ipv6 is disabled
-	cmd := exec.Command("ip", "-family", "inet6", "rule")
+	cmd := exec.Command("ip", ipFamilyFlag, "inet6", "rule")
 	if err := cmd.Run(); err != nil {
 		log.Trace().Err(err).Msg("ipv6 is disabled")
 		return false

--- a/go/action_kit_commons/network/netfault/netfault_test.go
+++ b/go/action_kit_commons/network/netfault/netfault_test.go
@@ -28,7 +28,7 @@ func TestApply_Order_IptablesBeforeTcWhenTcpPshOnly(t *testing.T) {
 	}
 
 	r := &fakeRunner{}
-	err := Apply(context.Background(), r, opts)
+	_, err := Apply(context.Background(), r, opts)
 	assert.NoError(t, err)
 
 	iptablesIdx := -1

--- a/go/action_kit_commons/network/netfault/runner_runc_test.go
+++ b/go/action_kit_commons/network/netfault/runner_runc_test.go
@@ -48,10 +48,10 @@ func Test_generateAndRunCommands_using_runc_should_serialize(t *testing.T) {
 
 			runner := NewRuncRunner(runcMock, sidecar)
 
-			_ = Apply(context.Background(), runner, &blackholeOpts)
-			defer func(ctx context.Context, runner CommandRunner, opts Opts) {
-				_ = Revert(ctx, runner, opts)
-			}(context.Background(), runner, &blackholeOpts)
+			snap, _ := Apply(context.Background(), runner, &blackholeOpts)
+			defer func(ctx context.Context, runner CommandRunner, opts Opts, snap QdiscSnapshot) {
+				_ = Revert(ctx, runner, opts, snap)
+			}(context.Background(), runner, &blackholeOpts, snap)
 		}()
 	}
 	wg.Wait()

--- a/go/action_kit_commons/network/netfault/snapshot.go
+++ b/go/action_kit_commons/network/netfault/snapshot.go
@@ -5,8 +5,6 @@
 package netfault
 
 import (
-	"sync"
-
 	"github.com/florianl/go-tc"
 )
 
@@ -21,48 +19,38 @@ import (
 //
 // Snapshot/restore uses RTNETLINK (github.com/florianl/go-tc) and only
 // takes effect on Linux. On non-Linux builds the path is a no-op.
+//
+// Lifecycle: Apply returns the captured snapshot, the caller stores it in
+// the action's per-execution state (via action_kit_sdk JSON state), and
+// passes it back to Revert. The library holds no cross-call state.
 
-// interfaceSnapshot holds the qdisc and filter state for one interface within
+// InterfaceSnapshot holds the qdisc and filter state for one interface within
 // a single network namespace.
-type interfaceSnapshot struct {
+type InterfaceSnapshot struct {
 	Name    string
 	Ifindex uint32
 	Qdiscs  []tc.Object
 	Filters []tc.Object
 }
 
-// qdiscSnapshot holds the snapshot for every interface an attack touches in a
-// network namespace.
-type qdiscSnapshot struct {
+// QdiscSnapshot holds the snapshot for every interface an attack touches in a
+// network namespace. The zero value (empty NetNsID, nil Interfaces) is a
+// valid "nothing to restore" sentinel — Revert treats it as a no-op.
+//
+// All fields are JSON-serializable so callers can persist the snapshot in
+// per-execution state (e.g. action_kit_sdk's state). The embedded tc.Object
+// values from github.com/florianl/go-tc roundtrip cleanly through
+// encoding/json (verified by TestQdiscSnapshotJSONRoundtrip).
+type QdiscSnapshot struct {
 	NetNsID    string
-	Interfaces map[string]interfaceSnapshot
+	Interfaces map[string]InterfaceSnapshot
 }
 
-// snapshotStore keeps snapshots in memory keyed by the runner's netns id. The
-// first concurrent attack on a netns takes the snapshot; subsequent attacks
-// reuse it. The last attack to be reverted triggers the restore.
-var (
-	snapshotStoreLock sync.Mutex
-	snapshotStore     = map[string]qdiscSnapshot{}
-)
-
-func storeSnapshot(snap qdiscSnapshot) {
-	snapshotStoreLock.Lock()
-	defer snapshotStoreLock.Unlock()
-	snapshotStore[snap.NetNsID] = snap
-}
-
-func loadSnapshot(netNsID string) (qdiscSnapshot, bool) {
-	snapshotStoreLock.Lock()
-	defer snapshotStoreLock.Unlock()
-	snap, ok := snapshotStore[netNsID]
-	return snap, ok
-}
-
-func deleteSnapshot(netNsID string) {
-	snapshotStoreLock.Lock()
-	defer snapshotStoreLock.Unlock()
-	delete(snapshotStore, netNsID)
+// IsEmpty reports whether the snapshot carries no per-interface state and
+// Revert should treat it as a no-op (e.g. strict mode was on at Apply time,
+// or the attack didn't touch a tc root qdisc).
+func (s QdiscSnapshot) IsEmpty() bool {
+	return len(s.Interfaces) == 0
 }
 
 // isKernelAutoManaged returns true for qdisc kinds the kernel automatically
@@ -209,7 +197,7 @@ func stripRuntimeStats(obj *tc.Object) {
 // matches the major of a saved root that (a) is itself kernel-auto-managed
 // and (b) has been replaced by a kernel-auto-managed root of the same kind
 // in the live tree. Everything else passes through unchanged.
-func reAnchorAutoManagedParents(ifSnap interfaceSnapshot, currentQdiscs []tc.Object) interfaceSnapshot {
+func reAnchorAutoManagedParents(ifSnap InterfaceSnapshot, currentQdiscs []tc.Object) InterfaceSnapshot {
 	rewrite := buildAutoManagedRewriteMap(ifSnap, currentQdiscs)
 	if len(rewrite) == 0 {
 		return ifSnap
@@ -221,7 +209,7 @@ func reAnchorAutoManagedParents(ifSnap interfaceSnapshot, currentQdiscs []tc.Obj
 // live counterpart on the same interface has a different major handle and
 // returns a saved-major → live-major map. Other saved roots and
 // non-auto-managed kinds contribute nothing.
-func buildAutoManagedRewriteMap(ifSnap interfaceSnapshot, currentQdiscs []tc.Object) map[uint32]uint32 {
+func buildAutoManagedRewriteMap(ifSnap InterfaceSnapshot, currentQdiscs []tc.Object) map[uint32]uint32 {
 	rewrite := map[uint32]uint32{}
 	for _, saved := range ifSnap.Qdiscs {
 		if !isRootQdisc(saved) || !isKernelAutoManaged(saved.Kind) {
@@ -247,13 +235,13 @@ func findLiveRootMajor(currentQdiscs []tc.Object, ifindex uint32, kind string) (
 	return 0, false
 }
 
-// applyParentRewrites returns a new interfaceSnapshot whose non-root child
+// applyParentRewrites returns a new InterfaceSnapshot whose non-root child
 // qdiscs have their Parent.major replaced via the rewrite map (minor is
 // preserved). The roots themselves are left untouched — the kernel
 // re-attaches them under their own (potentially still-different) live
 // handles.
-func applyParentRewrites(ifSnap interfaceSnapshot, rewrite map[uint32]uint32) interfaceSnapshot {
-	out := interfaceSnapshot{Name: ifSnap.Name, Ifindex: ifSnap.Ifindex, Filters: ifSnap.Filters}
+func applyParentRewrites(ifSnap InterfaceSnapshot, rewrite map[uint32]uint32) InterfaceSnapshot {
+	out := InterfaceSnapshot{Name: ifSnap.Name, Ifindex: ifSnap.Ifindex, Filters: ifSnap.Filters}
 	out.Qdiscs = make([]tc.Object, 0, len(ifSnap.Qdiscs))
 	for _, q := range ifSnap.Qdiscs {
 		if !isRootQdisc(q) {

--- a/go/action_kit_commons/network/netfault/snapshot_format.go
+++ b/go/action_kit_commons/network/netfault/snapshot_format.go
@@ -20,7 +20,7 @@ import (
 // Interface names are sorted so the output is stable across calls.
 // Per-interface, qdiscs are rendered in restore order (parent-first via
 // orderQdiscsForRestore) and filters are listed afterwards.
-func renderSnapshot(snap qdiscSnapshot) string {
+func renderSnapshot(snap QdiscSnapshot) string {
 	if len(snap.Interfaces) == 0 {
 		return "(empty snapshot)"
 	}
@@ -223,7 +223,7 @@ func formatMicroseconds(us uint32) string {
 // differences are ignored — those legitimately diverge after a restore.
 // Returns the empty string when the two snapshots are equivalent at the
 // shape level.
-func compareSnapshotsByHandle(before, after qdiscSnapshot) string {
+func compareSnapshotsByHandle(before, after QdiscSnapshot) string {
 	var diffs []string
 	for name, b := range before.Interfaces {
 		a, ok := after.Interfaces[name]

--- a/go/action_kit_commons/network/netfault/snapshot_format_test.go
+++ b/go/action_kit_commons/network/netfault/snapshot_format_test.go
@@ -20,9 +20,9 @@ import (
 // snapshot captured what they expect.
 func TestRenderSnapshot_GkeCosResemblesTcOutput(t *testing.T) {
 	const eth0 uint32 = 2
-	snap := qdiscSnapshot{
+	snap := QdiscSnapshot{
 		NetNsID: "test",
-		Interfaces: map[string]interfaceSnapshot{
+		Interfaces: map[string]InterfaceSnapshot{
 			"eth0": {Name: "eth0", Ifindex: eth0, Qdiscs: fixtureGkeCosEth0Tuned(eth0)},
 		},
 	}
@@ -51,16 +51,16 @@ func TestRenderSnapshot_GkeCosResemblesTcOutput(t *testing.T) {
 // distinguishable from a render bug (we explicitly print '(empty snapshot)'
 // rather than nothing).
 func TestRenderSnapshot_EmptyIsSelfDescribing(t *testing.T) {
-	assert.Equal(t, "(empty snapshot)", renderSnapshot(qdiscSnapshot{}))
+	assert.Equal(t, "(empty snapshot)", renderSnapshot(QdiscSnapshot{}))
 }
 
 // TestRenderSnapshot_SortedInterfaces ensures the rendered output is stable
 // across calls — two interfaces in the snapshot must always appear in the
 // same order, otherwise log diffing between captures becomes painful.
 func TestRenderSnapshot_SortedInterfaces(t *testing.T) {
-	snap := qdiscSnapshot{
+	snap := QdiscSnapshot{
 		NetNsID: "test",
-		Interfaces: map[string]interfaceSnapshot{
+		Interfaces: map[string]InterfaceSnapshot{
 			"zeth": {Name: "zeth", Ifindex: 3, Qdiscs: []tc.Object{{
 				Msg:       tc.Msg{Ifindex: 3, Handle: handle(1, 0), Parent: tcHRoot},
 				Attribute: tc.Attribute{Kind: "noqueue"},
@@ -83,10 +83,10 @@ func TestRenderSnapshot_SortedInterfaces(t *testing.T) {
 // triggers the "post-restore state matches snapshot" log message.
 func TestCompareSnapshotsByHandle_NoDiffForIdentical(t *testing.T) {
 	const eth0 uint32 = 2
-	a := qdiscSnapshot{Interfaces: map[string]interfaceSnapshot{
+	a := QdiscSnapshot{Interfaces: map[string]InterfaceSnapshot{
 		"eth0": {Name: "eth0", Ifindex: eth0, Qdiscs: fixtureGkeCosEth0Tuned(eth0)},
 	}}
-	b := qdiscSnapshot{Interfaces: map[string]interfaceSnapshot{
+	b := QdiscSnapshot{Interfaces: map[string]InterfaceSnapshot{
 		"eth0": {Name: "eth0", Ifindex: eth0, Qdiscs: fixtureGkeCosEth0Tuned(eth0)},
 	}}
 	assert.Empty(t, compareSnapshotsByHandle(a, b))
@@ -100,10 +100,10 @@ func TestCompareSnapshotsByHandle_DetectsMissingChild(t *testing.T) {
 	full := fixtureGkeCosEth0Tuned(eth0)
 	partial := full[:len(full)-1] // drop the last fq child
 
-	before := qdiscSnapshot{Interfaces: map[string]interfaceSnapshot{
+	before := QdiscSnapshot{Interfaces: map[string]InterfaceSnapshot{
 		"eth0": {Name: "eth0", Ifindex: eth0, Qdiscs: full},
 	}}
-	after := qdiscSnapshot{Interfaces: map[string]interfaceSnapshot{
+	after := QdiscSnapshot{Interfaces: map[string]InterfaceSnapshot{
 		"eth0": {Name: "eth0", Ifindex: eth0, Qdiscs: partial},
 	}}
 	diff := compareSnapshotsByHandle(before, after)
@@ -127,10 +127,10 @@ func TestCompareSnapshotsByHandle_IgnoresKernelAutoManaged(t *testing.T) {
 			noMq = append(noMq, q)
 		}
 	}
-	before := qdiscSnapshot{Interfaces: map[string]interfaceSnapshot{
+	before := QdiscSnapshot{Interfaces: map[string]InterfaceSnapshot{
 		"eth0": {Name: "eth0", Ifindex: eth0, Qdiscs: full},
 	}}
-	after := qdiscSnapshot{Interfaces: map[string]interfaceSnapshot{
+	after := QdiscSnapshot{Interfaces: map[string]InterfaceSnapshot{
 		"eth0": {Name: "eth0", Ifindex: eth0, Qdiscs: noMq},
 	}}
 	assert.Empty(t, compareSnapshotsByHandle(before, after), "mq absence must be ignored — it's kernel-auto-managed")

--- a/go/action_kit_commons/network/netfault/snapshot_json_test.go
+++ b/go/action_kit_commons/network/netfault/snapshot_json_test.go
@@ -115,13 +115,25 @@ func buildRepresentativeSnapshot() QdiscSnapshot {
 		},
 	}
 
+	// clsact and ingress share the same kernel slot
+	// (TC_H_CLSACT == TC_H_INGRESS == 0xffff0000) so a real interface only
+	// ever carries one. We exercise both kinds in the JSON roundtrip by
+	// putting them on different interfaces (eth0 has clsact alongside mq+fq;
+	// eth3 has ingress on its own). The handle + parent values match what
+	// the kernel reports — handleMajor(parent) == handleMajor(handle), but
+	// the topological sort treats them as roots via isRootQdisc only when
+	// Parent is TC_H_ROOT or 0; here they're hook qdiscs and fall through
+	// the cycle-detection fallback in orderQdiscsForRestore. That's fine for
+	// the restore path (isKernelAutoManaged skips them), but it would be
+	// confusing if a future test reused this fixture against ordering code,
+	// so keep them apart.
 	clsact := tc.Object{
 		Msg:       tc.Msg{Ifindex: 2, Handle: 0xffff0000, Parent: 0xfffffff1},
 		Attribute: tc.Attribute{Kind: "clsact"},
 	}
 
 	ingress := tc.Object{
-		Msg:       tc.Msg{Ifindex: 2, Handle: 0xffff0000, Parent: 0xfffffff1},
+		Msg:       tc.Msg{Ifindex: 6, Handle: 0xffff0000, Parent: 0xfffffff1},
 		Attribute: tc.Attribute{Kind: "ingress"},
 	}
 
@@ -162,8 +174,14 @@ func buildRepresentativeSnapshot() QdiscSnapshot {
 			"eth0": {
 				Name:    "eth0",
 				Ifindex: 2,
-				Qdiscs:  []tc.Object{mqRoot, fqChild, clsact, ingress},
+				Qdiscs:  []tc.Object{mqRoot, fqChild, clsact},
 				Filters: []tc.Object{filter},
+			},
+			"eth3": {
+				Name:    "eth3",
+				Ifindex: 6,
+				Qdiscs:  []tc.Object{ingress},
+				Filters: nil,
 			},
 			"eth1": {
 				Name:    "eth1",

--- a/go/action_kit_commons/network/netfault/snapshot_json_test.go
+++ b/go/action_kit_commons/network/netfault/snapshot_json_test.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Steadybit GmbH
+//go:build !windows
+
+package netfault
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/florianl/go-tc"
+)
+
+// TestQdiscSnapshotJSONRoundtrip verifies that a qdiscSnapshot survives
+// json.Marshal -> json.Unmarshal with structural identity. This is the
+// gating experiment for moving the snapshot off the in-memory store and
+// into the action_kit_sdk per-execution state, which serializes via JSON.
+//
+// If this test passes, the post-roundtrip object is byte-for-byte
+// equivalent to the pre-roundtrip object and feeding it to
+// Qdisc().Replace() is equivalent to feeding the original.
+//
+// If this test fails, fields are being lost or transformed by JSON and the
+// approach needs a custom marshal layer.
+func TestQdiscSnapshotJSONRoundtrip(t *testing.T) {
+	original := buildRepresentativeSnapshot()
+
+	encoded, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded QdiscSnapshot
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if !reflect.DeepEqual(original, decoded) {
+		t.Fatalf("roundtrip changed snapshot.\n  before: %#v\n  after:  %#v", original, decoded)
+	}
+
+	// Belt-and-braces: confirm the JSON actually carries the tuned values
+	// the customer cares about. A "null everywhere" JSON would also
+	// trivially roundtrip-equal, so we explicitly assert that the fq
+	// buckets-log and horizon are persisted.
+	if !strings.Contains(string(encoded), `"BucketsLog":15`) {
+		t.Errorf("BucketsLog=15 (GKE-tuned 32768 buckets) missing from JSON output:\n%s", encoded)
+	}
+	if !strings.Contains(string(encoded), `"Horizon":2000000`) {
+		t.Errorf("Horizon=2000000 (GKE-tuned 2s) missing from JSON output:\n%s", encoded)
+	}
+	if !strings.Contains(string(encoded), `"Kind":"fq"`) {
+		t.Errorf("fq qdisc kind missing from JSON output:\n%s", encoded)
+	}
+}
+
+// buildRepresentativeSnapshot constructs a qdiscSnapshot that covers every
+// shape the restore path actually replays:
+//   - mq root (kernel auto-managed, kept in snapshot for re-anchoring)
+//   - fq child with tuned BucketsLog + Horizon (the customer's GKE profile)
+//   - prio root (used on some EKS setups)
+//   - clsact + ingress (kernel auto-managed, hook qdiscs)
+//   - pfifo_fast / noqueue (kernel default leaves)
+//   - htb root with class hierarchy (multi-tenant rate limiting)
+//   - one filter so the Filters slice exercises the same path
+func buildRepresentativeSnapshot() QdiscSnapshot {
+	u32 := func(v uint32) *uint32 { return &v }
+
+	mqRoot := tc.Object{
+		Msg: tc.Msg{
+			Family:  0,
+			Ifindex: 2,
+			Handle:  0x80260000,
+			Parent:  tcHRoot,
+			Info:    0,
+		},
+		Attribute: tc.Attribute{Kind: "mq"},
+	}
+
+	fqChild := tc.Object{
+		Msg: tc.Msg{
+			Family:  0,
+			Ifindex: 2,
+			Handle:  0x802b0000,
+			Parent:  0x80260001,
+			Info:    0,
+		},
+		Attribute: tc.Attribute{
+			Kind: "fq",
+			Fq: &tc.Fq{
+				PLimit:     u32(10000),
+				FlowPLimit: u32(100),
+				Quantum:    u32(3028),
+				BucketsLog: u32(15), // 32768 buckets — the GKE-tuned value
+				Horizon:    u32(2000000),
+				PrioMap: &tc.FqPrioQopt{
+					Bands:   3,
+					PrioMap: [16]uint8{1, 2, 2, 2, 1, 2, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1},
+				},
+				Weights: &[]int32{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+			},
+		},
+	}
+
+	prio := tc.Object{
+		Msg: tc.Msg{Ifindex: 3, Handle: 0x10000, Parent: tcHRoot},
+		Attribute: tc.Attribute{
+			Kind: "prio",
+			Prio: &tc.Prio{
+				Bands:   3,
+				PrioMap: [16]uint8{1, 2, 2, 2, 1, 2, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1},
+			},
+		},
+	}
+
+	clsact := tc.Object{
+		Msg:       tc.Msg{Ifindex: 2, Handle: 0xffff0000, Parent: 0xfffffff1},
+		Attribute: tc.Attribute{Kind: "clsact"},
+	}
+
+	ingress := tc.Object{
+		Msg:       tc.Msg{Ifindex: 2, Handle: 0xffff0000, Parent: 0xfffffff1},
+		Attribute: tc.Attribute{Kind: "ingress"},
+	}
+
+	pfifoFast := tc.Object{
+		Msg:       tc.Msg{Ifindex: 5, Handle: 0, Parent: tcHRoot},
+		Attribute: tc.Attribute{Kind: "pfifo_fast"},
+	}
+
+	noqueue := tc.Object{
+		Msg:       tc.Msg{Ifindex: 1, Handle: 0, Parent: tcHRoot},
+		Attribute: tc.Attribute{Kind: "noqueue"},
+	}
+
+	htbRoot := tc.Object{
+		Msg: tc.Msg{Ifindex: 4, Handle: 0x10000, Parent: tcHRoot},
+		Attribute: tc.Attribute{
+			Kind: "htb",
+			Htb: &tc.Htb{
+				Init: &tc.HtbGlob{
+					Version:      0x30000,
+					Rate2Quantum: 10,
+					Defcls:       0,
+				},
+			},
+		},
+	}
+
+	filter := tc.Object{
+		Msg: tc.Msg{Ifindex: 2, Handle: 0x1, Parent: 0x80260001, Info: 0x300},
+		Attribute: tc.Attribute{
+			Kind: "u32",
+		},
+	}
+
+	return QdiscSnapshot{
+		NetNsID: "/proc/12345/ns/net",
+		Interfaces: map[string]InterfaceSnapshot{
+			"eth0": {
+				Name:    "eth0",
+				Ifindex: 2,
+				Qdiscs:  []tc.Object{mqRoot, fqChild, clsact, ingress},
+				Filters: []tc.Object{filter},
+			},
+			"eth1": {
+				Name:    "eth1",
+				Ifindex: 3,
+				Qdiscs:  []tc.Object{prio},
+				Filters: nil,
+			},
+			"vethX": {
+				Name:    "vethX",
+				Ifindex: 5,
+				Qdiscs:  []tc.Object{pfifoFast},
+				Filters: nil,
+			},
+			"lo": {
+				Name:    "lo",
+				Ifindex: 1,
+				Qdiscs:  []tc.Object{noqueue},
+				Filters: nil,
+			},
+			"eth2": {
+				Name:    "eth2",
+				Ifindex: 4,
+				Qdiscs:  []tc.Object{htbRoot},
+				Filters: nil,
+			},
+		},
+	}
+}

--- a/go/action_kit_commons/network/netfault/snapshot_linux.go
+++ b/go/action_kit_commons/network/netfault/snapshot_linux.go
@@ -36,8 +36,8 @@ func openNetNs(path string) (*os.File, error) {
 // takeSnapshot captures the root qdisc tree and filters for every interface in
 // `interfaces` within the netns identified by `netNsFd`. Interfaces not found
 // in the netns are silently skipped (they may be CNI veths that come and go).
-func takeSnapshot(netNsFd int, netNsID string, interfaces []string) (qdiscSnapshot, error) {
-	snap := qdiscSnapshot{NetNsID: netNsID, Interfaces: map[string]interfaceSnapshot{}}
+func takeSnapshot(netNsFd int, netNsID string, interfaces []string) (QdiscSnapshot, error) {
+	snap := QdiscSnapshot{NetNsID: netNsID, Interfaces: map[string]InterfaceSnapshot{}}
 
 	conn, err := tc.Open(&tc.Config{NetNS: netNsFd})
 	if err != nil {
@@ -65,7 +65,7 @@ func takeSnapshot(netNsFd int, netNsID string, interfaces []string) (qdiscSnapsh
 			log.Trace().Str("interface", name).Msg("interface not present in netns; skipping snapshot")
 			continue
 		}
-		ifSnap := interfaceSnapshot{Name: name, Ifindex: idx}
+		ifSnap := InterfaceSnapshot{Name: name, Ifindex: idx}
 		for _, q := range qdiscs {
 			if q.Ifindex == idx {
 				ifSnap.Qdiscs = append(ifSnap.Qdiscs, q)
@@ -78,7 +78,7 @@ func takeSnapshot(netNsFd int, netNsID string, interfaces []string) (qdiscSnapsh
 			// incomplete one — a partial snapshot leads to orphaned filter
 			// state on restore, which is worse than no snapshot at all
 			// (revert then degrades gracefully to the existing tc-del path).
-			return qdiscSnapshot{NetNsID: netNsID}, fmt.Errorf("read filters on %s: %w", name, ferr)
+			return QdiscSnapshot{NetNsID: netNsID}, fmt.Errorf("read filters on %s: %w", name, ferr)
 		}
 		ifSnap.Filters = filters
 
@@ -99,7 +99,7 @@ func takeSnapshot(netNsFd int, netNsID string, interfaces []string) (qdiscSnapsh
 //
 // Restore failures are logged but do not stop the loop; we attempt to restore
 // as much state as possible. Per-qdisc errors are joined and returned.
-func restoreSnapshot(netNsFd int, snap qdiscSnapshot) error {
+func restoreSnapshot(netNsFd int, snap QdiscSnapshot) error {
 	conn, err := tc.Open(&tc.Config{NetNS: netNsFd})
 	if err != nil {
 		return fmt.Errorf("open tc netlink connection: %w", err)
@@ -135,7 +135,7 @@ func restoreSnapshot(netNsFd int, snap qdiscSnapshot) error {
 // returns 0); any attempt to attach a saved child with the old handle then
 // fails with ENOENT. We use a raw RTNETLINK message (claimAutoManagedRoot)
 // because go-tc's validateQdiscObject lacks an "mq" case.
-func claimAutoManagedRootHandles(netNsFd int, snap qdiscSnapshot) {
+func claimAutoManagedRootHandles(netNsFd int, snap QdiscSnapshot) {
 	for name, ifSnap := range snap.Interfaces {
 		for _, q := range ifSnap.Qdiscs {
 			if !shouldClaimRoot(q) {
@@ -157,7 +157,7 @@ func shouldClaimRoot(q tc.Object) bool {
 // restoreInterfaceQdiscs replays the saved qdiscs for one interface in
 // parent-first order. Kernel-auto-managed kinds are skipped; the rest are
 // Replace()d after their kernel-counter fields are zeroed.
-func restoreInterfaceQdiscs(conn *tc.Tc, name string, ifSnap interfaceSnapshot) error {
+func restoreInterfaceQdiscs(conn *tc.Tc, name string, ifSnap InterfaceSnapshot) error {
 	var combined error
 	for _, q := range orderQdiscsForRestore(ifSnap.Qdiscs) {
 		if shouldSkipQdiscOnRestore(q) {
@@ -179,7 +179,7 @@ func restoreInterfaceQdiscs(conn *tc.Tc, name string, ifSnap interfaceSnapshot) 
 // restoreInterfaceFilters replays the saved filters for one interface via
 // Replace() (not Add) so leftover filters from incomplete attack cleanup
 // are overwritten rather than rejected with "File exists".
-func restoreInterfaceFilters(conn *tc.Tc, name string, ifSnap interfaceSnapshot) error {
+func restoreInterfaceFilters(conn *tc.Tc, name string, ifSnap InterfaceSnapshot) error {
 	var combined error
 	for _, f := range ifSnap.Filters {
 		obj := f

--- a/go/action_kit_commons/network/netfault/snapshot_other.go
+++ b/go/action_kit_commons/network/netfault/snapshot_other.go
@@ -18,10 +18,10 @@ func openNetNs(_ string) (*os.File, error) {
 	return nil, errSnapshotUnsupported
 }
 
-func takeSnapshot(_ int, netNsID string, _ []string) (qdiscSnapshot, error) {
-	return qdiscSnapshot{NetNsID: netNsID, Interfaces: map[string]interfaceSnapshot{}}, errSnapshotUnsupported
+func takeSnapshot(_ int, netNsID string, _ []string) (QdiscSnapshot, error) {
+	return QdiscSnapshot{NetNsID: netNsID, Interfaces: map[string]InterfaceSnapshot{}}, errSnapshotUnsupported
 }
 
-func restoreSnapshot(_ int, _ qdiscSnapshot) error {
+func restoreSnapshot(_ int, _ QdiscSnapshot) error {
 	return errSnapshotUnsupported
 }

--- a/go/action_kit_commons/network/netfault/snapshot_realistic_test.go
+++ b/go/action_kit_commons/network/netfault/snapshot_realistic_test.go
@@ -59,34 +59,27 @@ func TestRestorePlan_GkeCosCustomerCase(t *testing.T) {
 }
 
 // TestRestorePlan_GkeCosMultiInterface covers the full snapshot for a GKE
-// COS node: eth0 with tuned mq+fq, lo with noqueue. After revert the
-// snapshot store should round-trip both and the planner should issue the
-// right action for each interface independently.
+// COS node: eth0 with tuned mq+fq, lo with noqueue. The planner must issue
+// the right action for each interface independently.
 func TestRestorePlan_GkeCosMultiInterface(t *testing.T) {
 	const eth0 uint32 = 2
 	const lo uint32 = 1
-	t.Cleanup(func() { deleteSnapshot("gke-multi") })
-
-	snap := qdiscSnapshot{
+	snap := QdiscSnapshot{
 		NetNsID: "gke-multi",
-		Interfaces: map[string]interfaceSnapshot{
+		Interfaces: map[string]InterfaceSnapshot{
 			"eth0": {Name: "eth0", Ifindex: eth0, Qdiscs: fixtureGkeCosEth0Tuned(eth0)},
 			"lo":   {Name: "lo", Ifindex: lo, Qdiscs: fixtureGkeCosLoopback(lo)},
 		},
 	}
-	storeSnapshot(snap)
-
-	got, ok := loadSnapshot("gke-multi")
-	require.True(t, ok)
-	require.Len(t, got.Interfaces, 2)
+	require.Len(t, snap.Interfaces, 2)
 
 	// eth0: 1 skip (mq) + 16 replaces (fq children)
-	plan := planForInterface(got.Interfaces["eth0"].Qdiscs)
+	plan := planForInterface(snap.Interfaces["eth0"].Qdiscs)
 	assert.Equal(t, planCounts{skip: 1, replace: 16}, plan, "eth0: skip mq, replace 16 fq children")
 
 	// lo: noqueue is in isKernelAutoManaged — stateless, kernel re-attaches
 	// it automatically, and go-tc doesn't implement Replace for it.
-	plan = planForInterface(got.Interfaces["lo"].Qdiscs)
+	plan = planForInterface(snap.Interfaces["lo"].Qdiscs)
 	assert.Equal(t, planCounts{skip: 1, replace: 0}, plan, "lo: noqueue is kernel-auto-managed, skipped on restore")
 }
 
@@ -221,17 +214,12 @@ func TestRestorePlan_OrderingThreeLevelNesting(t *testing.T) {
 
 // TestRestorePlan_EmptySnapshot covers veth/CNI interfaces with no
 // pre-existing root qdisc (a fresh netns). The snapshot captures nothing
-// and restore is a no-op. Important: storeSnapshot should NOT later think
-// there's nothing to restore and crash; it should just iterate over an
-// empty map.
+// and IsEmpty reports true so Revert skips the restore path.
 func TestRestorePlan_EmptySnapshot(t *testing.T) {
-	t.Cleanup(func() { deleteSnapshot("empty-ns") })
+	snap := QdiscSnapshot{NetNsID: "empty-ns", Interfaces: map[string]InterfaceSnapshot{}}
 
-	storeSnapshot(qdiscSnapshot{NetNsID: "empty-ns", Interfaces: map[string]interfaceSnapshot{}})
-
-	got, ok := loadSnapshot("empty-ns")
-	require.True(t, ok)
-	assert.Empty(t, got.Interfaces, "empty snapshot has no interfaces to restore")
+	assert.True(t, snap.IsEmpty(), "empty interfaces map -> no restore work")
+	assert.Empty(t, snap.Interfaces)
 }
 
 // TestRestorePlan_MqWithoutChildren covers the (rare) case where an mq root
@@ -246,39 +234,6 @@ func TestRestorePlan_MqWithoutChildren(t *testing.T) {
 	}}
 	plan := planForInterface(qdiscs)
 	assert.Equal(t, planCounts{skip: 1, replace: 0}, plan)
-}
-
-// TestRestorePlan_StoreLifecycleAcrossMultipleAttacks simulates the
-// snapshot-store guard: the first attack on a netns takes a snapshot; a
-// second concurrent attack on the same netns reuses the existing snapshot
-// (loadSnapshot returns ok=true) without overwriting it. Lifecycle ends
-// when the last attack reverts and we call deleteSnapshot.
-func TestRestorePlan_StoreLifecycleAcrossMultipleAttacks(t *testing.T) {
-	const netNs = "multi-attack"
-	t.Cleanup(func() { deleteSnapshot(netNs) })
-
-	// First attack takes snapshot.
-	_, exists := loadSnapshot(netNs)
-	assert.False(t, exists)
-	storeSnapshot(qdiscSnapshot{
-		NetNsID:    netNs,
-		Interfaces: map[string]interfaceSnapshot{"eth0": {Name: "eth0", Qdiscs: fixtureGkeCosEth0Tuned(2)}},
-	})
-	first, _ := loadSnapshot(netNs)
-	firstQdiscCount := len(first.Interfaces["eth0"].Qdiscs)
-
-	// Second concurrent attack arrives — loadSnapshot says one already
-	// exists, so the caller should skip taking another.
-	_, exists = loadSnapshot(netNs)
-	assert.True(t, exists, "second attack should see existing snapshot and skip taking another")
-
-	// Last attack reverts: load + restore + delete.
-	loaded, ok := loadSnapshot(netNs)
-	require.True(t, ok)
-	assert.Equal(t, firstQdiscCount, len(loaded.Interfaces["eth0"].Qdiscs), "snapshot must be unchanged from first attack's capture")
-	deleteSnapshot(netNs)
-	_, exists = loadSnapshot(netNs)
-	assert.False(t, exists)
 }
 
 // planCounts aggregates planner decisions for an interface so tests can

--- a/go/action_kit_commons/network/netfault/snapshot_regression_test.go
+++ b/go/action_kit_commons/network/netfault/snapshot_regression_test.go
@@ -89,7 +89,7 @@ func TestReAnchorAutoManagedParents_RewritesGkeStyleMqChildren(t *testing.T) {
 	savedMqMajor := uint32(0x80260000)
 	liveMqMajor := uint32(0x00000000) // kernel re-attaches mq with handle 0:
 
-	saved := interfaceSnapshot{
+	saved := InterfaceSnapshot{
 		Name:    "eth0",
 		Ifindex: eth0,
 		Qdiscs: []tc.Object{
@@ -127,7 +127,7 @@ func TestReAnchorAutoManagedParents_RewritesGkeStyleMqChildren(t *testing.T) {
 // through untouched.
 func TestReAnchorAutoManagedParents_NoMatchingRootIsNoOp(t *testing.T) {
 	const eth0 uint32 = 2
-	saved := interfaceSnapshot{
+	saved := InterfaceSnapshot{
 		Name:    "eth0",
 		Ifindex: eth0,
 		Qdiscs: []tc.Object{
@@ -150,7 +150,7 @@ func TestReAnchorAutoManagedParents_NoMatchingRootIsNoOp(t *testing.T) {
 // clsact, we must not rewrite (the relationship doesn't carry over).
 func TestReAnchorAutoManagedParents_OnlyRewritesMatchingKind(t *testing.T) {
 	const eth0 uint32 = 2
-	saved := interfaceSnapshot{
+	saved := InterfaceSnapshot{
 		Name:    "eth0",
 		Ifindex: eth0,
 		Qdiscs: []tc.Object{
@@ -174,7 +174,7 @@ func TestReAnchorAutoManagedParents_OnlyRewritesMatchingKind(t *testing.T) {
 func TestReAnchorAutoManagedParents_FiltersIfindex(t *testing.T) {
 	const eth0 uint32 = 2
 	const eth1 uint32 = 3
-	saved := interfaceSnapshot{
+	saved := InterfaceSnapshot{
 		Name:    "eth0",
 		Ifindex: eth0,
 		Qdiscs: []tc.Object{
@@ -199,7 +199,7 @@ func TestReAnchorAutoManagedParents_FiltersIfindex(t *testing.T) {
 func TestReAnchorAutoManagedParents_PreservesAllFields(t *testing.T) {
 	const eth0 uint32 = 2
 	tunedFq := &tc.Fq{BucketsLog: uint32Ptr(15), Horizon: uint32Ptr(2_000_000)}
-	saved := interfaceSnapshot{
+	saved := InterfaceSnapshot{
 		Name:    "eth0",
 		Ifindex: eth0,
 		Qdiscs: []tc.Object{

--- a/go/action_kit_commons/network/netfault/snapshot_test.go
+++ b/go/action_kit_commons/network/netfault/snapshot_test.go
@@ -87,40 +87,13 @@ func TestOrderQdiscsForRestore_RootsBeforeChildren(t *testing.T) {
 	}
 }
 
-func TestSnapshotStore_Roundtrip(t *testing.T) {
-	t.Cleanup(func() { deleteSnapshot("test-roundtrip") })
-
-	_, ok := loadSnapshot("test-roundtrip")
-	assert.False(t, ok, "store starts empty for this id")
-
-	snap := qdiscSnapshot{
-		NetNsID: "test-roundtrip",
-		Interfaces: map[string]interfaceSnapshot{
-			"eth0": {Name: "eth0", Ifindex: 2},
-		},
-	}
-	storeSnapshot(snap)
-
-	got, ok := loadSnapshot("test-roundtrip")
-	assert.True(t, ok)
-	assert.Equal(t, "test-roundtrip", got.NetNsID)
-	assert.Contains(t, got.Interfaces, "eth0")
-	assert.Equal(t, uint32(2), got.Interfaces["eth0"].Ifindex)
-
-	deleteSnapshot("test-roundtrip")
-	_, ok = loadSnapshot("test-roundtrip")
-	assert.False(t, ok)
-}
-
-func TestSnapshotStore_OverwriteSameNetNs(t *testing.T) {
-	t.Cleanup(func() { deleteSnapshot("test-overwrite") })
-
-	storeSnapshot(qdiscSnapshot{NetNsID: "test-overwrite", Interfaces: map[string]interfaceSnapshot{"eth0": {Name: "eth0"}}})
-	storeSnapshot(qdiscSnapshot{NetNsID: "test-overwrite", Interfaces: map[string]interfaceSnapshot{"eth1": {Name: "eth1"}}})
-
-	got, ok := loadSnapshot("test-overwrite")
-	assert.True(t, ok)
-	assert.NotContains(t, got.Interfaces, "eth0", "second store should replace, not merge")
-	assert.Contains(t, got.Interfaces, "eth1")
+func TestQdiscSnapshot_IsEmpty(t *testing.T) {
+	assert.True(t, QdiscSnapshot{}.IsEmpty(), "zero value is empty")
+	assert.True(t, QdiscSnapshot{NetNsID: "x"}.IsEmpty(), "no interfaces is empty (regardless of NetNsID)")
+	assert.True(t, QdiscSnapshot{Interfaces: map[string]InterfaceSnapshot{}}.IsEmpty(), "empty map is empty")
+	assert.False(t,
+		QdiscSnapshot{Interfaces: map[string]InterfaceSnapshot{"eth0": {Name: "eth0"}}}.IsEmpty(),
+		"at least one interface makes it non-empty",
+	)
 }
 


### PR DESCRIPTION
## Summary

- Move the netfault qdisc snapshot from the process-local `snapshotStore` map into caller-owned state. `Apply` now returns `(QdiscSnapshot, error)`; `Revert` takes the snapshot as a fourth argument. `QdiscSnapshot` + `InterfaceSnapshot` are exported and JSON-serializable so extensions can persist them in their per-execution state.
- Drop the cross-attack dedup. With `activeNetfault` already serializing network attacks per netns at `pushActiveNetfault`, the "first attack snapshots, last revert restores" optimisation was a no-op.
- Add `TestQdiscSnapshotJSONRoundtrip` as a permanent regression test. It builds a representative snapshot (mq root, fq with tuned `BucketsLog=15` / `Horizon=2000000`, prio, htb, clsact, ingress, pfifo_fast, noqueue, plus a filter) and asserts `reflect.DeepEqual` after `json.Marshal` → `json.Unmarshal`, plus that the tuned values literally appear in the encoded bytes.

## Why

With the in-memory store, an extension pod restart between Apply and Revert lost the snapshot and Revert degraded to the kernel-default-restore behaviour we shipped 1.9.0 to fix. Moving the snapshot into the action's per-execution state means the Steadybit platform holds it and Revert restores the original (cloud-tuned) tree regardless of pod lifecycle.

## Caller migration

```go
// before
err := netfault.Apply(ctx, runner, opts)
// ...
err = netfault.Revert(ctx, runner, opts)

// after
snap, err := netfault.Apply(ctx, runner, opts)
// stash snap in your action's per-execution state, then later:
err = netfault.Revert(ctx, runner, opts, snap)
```

Callers that don't care about preserving the pre-attack tree (e.g. iptables-only attacks like the NTP blackhole in extension-host) can pass `netfault.QdiscSnapshot{}` to Revert and discard the value from Apply — the zero snapshot is a documented no-op (`IsEmpty()` reports true).

## Test plan

- [x] `go test ./network/netfault/ -count=1` passes (full netfault suite, 6.9s)
- [x] `go test ./... -count=1` passes (whole `action_kit_commons` module)
- [x] `TestQdiscSnapshotJSONRoundtrip` proves `tc.Object` survives JSON with structural identity
- [x] Verified against extension-host and extension-container with a local `replace` directive — both build and pass their unit suites against this branch
- [ ] CI green on PR