### PR TITLE
fix: robustness and injection hardening in action_kit_commons

### DIFF
--- a/go/action_kit_commons/CHANGELOG.md
+++ b/go/action_kit_commons/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- fix: guard runtime crash paths — no nil-deref reading a process exit code when a runtime binary fails to start, no index panic parsing empty runtime output (`ociruntime`), no divide-by-zero when a netfault attack has no interfaces, and no nil-deref when a stress/memfill/diskfill process wrapper's `Exited`/`Stop` is called without a successful `Start`
+- fix: reject newline injection into `tc`/`iptables` batch stdin and into `dig` stdin, so an unsanitized interface name / rate / hostname forwarded from user input can no longer inject an extra privileged command; also capture the process pid before the SIGTERM timer goroutine to avoid a data race, and skip un-parseable IPs in DNS resolution
+
 ## 1.10.0
 
 - **Breaking:** netfault snapshot now lives in caller-owned state, not a process-local map.

--- a/go/action_kit_commons/diskfill/diskfill_process.go
+++ b/go/action_kit_commons/diskfill/diskfill_process.go
@@ -38,6 +38,10 @@ func NewDiskfillProcess(ctx context.Context, opts Opts) (Diskfill, error) {
 }
 
 func (df *diskfillProcess) Exited() (bool, error) {
+	if df.state == nil {
+		// Start was never called (or failed): there is no running process.
+		return true, nil
+	}
 	return df.state.Exited()
 }
 
@@ -59,14 +63,21 @@ func (df *diskfillProcess) Stop() error {
 	log.Info().
 		Msg("stopping diskfill")
 
+	if df.cmd.Process == nil || df.state == nil {
+		// never started (or start failed) — nothing to stop
+		return nil
+	}
 	//as the process is running with a different user, we also need to do so, for sending signals
 	ctx := context.Background()
-	if err := utils.RootCommandContext(ctx, "kill", "-s", "SIGINT", strconv.Itoa(df.cmd.Process.Pid)).Run(); err != nil {
+	// Capture the pid up front so the timer goroutine doesn't read df.cmd.Process
+	// concurrently with the exec waiter.
+	pid := strconv.Itoa(df.cmd.Process.Pid)
+	if err := utils.RootCommandContext(ctx, "kill", "-s", "SIGINT", pid).Run(); err != nil {
 		log.Warn().Err(err).Msg("failed to send SIGINT to diskfill")
 	}
 
 	timer := time.AfterFunc(10*time.Second, func() {
-		if err := utils.RootCommandContext(ctx, "kill", "-s", "SIGTERM", strconv.Itoa(df.cmd.Process.Pid)).Run(); err != nil {
+		if err := utils.RootCommandContext(ctx, "kill", "-s", "SIGTERM", pid).Run(); err != nil {
 			log.Warn().Err(err).Msg("failed to send SIGTERM to diskfill")
 		}
 	})

--- a/go/action_kit_commons/diskfill/diskfill_runc.go
+++ b/go/action_kit_commons/diskfill/diskfill_runc.go
@@ -53,6 +53,10 @@ func NewDiskfillRunc(ctx context.Context, r ociruntime.OciRuntime, sidecar Sidec
 }
 
 func (df *diskfillRunc) Exited() (bool, error) {
+	if df.state == nil {
+		// Start was never called (or failed): there is no running process.
+		return true, nil
+	}
 	return df.state.Exited()
 }
 
@@ -74,6 +78,11 @@ func (df *diskfillRunc) Stop() error {
 	log.Info().
 		Str("containerId", df.bundle.ContainerId()).
 		Msg("stopping diskfill")
+
+	if df.state == nil {
+		// never started (or start failed) — nothing to stop
+		return nil
+	}
 	ctx := context.Background()
 
 	//stop writer

--- a/go/action_kit_commons/memfill/memfill_process.go
+++ b/go/action_kit_commons/memfill/memfill_process.go
@@ -37,6 +37,10 @@ func NewMemfillProcess(targetProcess ociruntime.LinuxProcessInfo, opts Opts) (Me
 }
 
 func (mf *memfillRunc) Exited() (bool, error) {
+	if mf.state == nil {
+		// Start was never called (or failed): there is no running process.
+		return true, nil
+	}
 	return mf.state.Exited()
 }
 
@@ -58,14 +62,21 @@ func (mf *memfillRunc) Stop() error {
 	log.Info().
 		Msg("stopping memfill")
 
+	if mf.cmd.Process == nil || mf.state == nil {
+		// never started (or start failed) — nothing to stop
+		return nil
+	}
 	//as the process is running with a different user, we also need to do so, for sending signals
 	ctx := context.Background()
-	if err := utils.RootCommandContext(ctx, "kill", "-s", "SIGINT", strconv.Itoa(mf.cmd.Process.Pid)).Run(); err != nil {
+	// Capture the pid up front so the timer goroutine doesn't read mf.cmd.Process
+	// concurrently with the exec waiter.
+	pid := strconv.Itoa(mf.cmd.Process.Pid)
+	if err := utils.RootCommandContext(ctx, "kill", "-s", "SIGINT", pid).Run(); err != nil {
 		log.Warn().Err(err).Msg("failed to send SIGINT to memfill")
 	}
 
 	timer := time.AfterFunc(10*time.Second, func() {
-		if err := utils.RootCommandContext(ctx, "kill", "-s", "SIGTERM", strconv.Itoa(mf.cmd.Process.Pid)).Run(); err != nil {
+		if err := utils.RootCommandContext(ctx, "kill", "-s", "SIGTERM", pid).Run(); err != nil {
 			log.Warn().Err(err).Msg("failed to send SIGTERM to memfill")
 		}
 	})

--- a/go/action_kit_commons/network/dnsresolve/resolve.go
+++ b/go/action_kit_commons/network/dnsresolve/resolve.go
@@ -14,6 +14,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/rs/zerolog/log"
 )
@@ -39,7 +40,10 @@ func resolve(ctx context.Context, d dig, hostnames ...string) ([]net.IP, error) 
 	var invalid []string
 	var sb strings.Builder
 	for _, hostname := range hostnames {
-		if len(strings.TrimSpace(hostname)) == 0 {
+		// Reject empty hostnames and any containing whitespace: hostnames are written
+		// line-by-line into dig's `-f-` stdin, so a space or newline would inject an
+		// additional dig query. Valid DNS hostnames never contain whitespace.
+		if len(strings.TrimSpace(hostname)) == 0 || strings.ContainsFunc(hostname, unicode.IsSpace) {
 			invalid = append(invalid, hostname)
 			continue
 		}
@@ -67,8 +71,13 @@ func resolve(ctx context.Context, d dig, hostnames ...string) ([]net.IP, error) 
 			messages = append(messages, strings.TrimSpace(strings.TrimPrefix(line, ";;")))
 			continue
 		} else if fields := strings.Fields(line); len(fields) >= 4 {
+			ip := net.ParseIP(fields[3])
+			if ip == nil {
+				// Skip lines whose answer isn't a valid IP rather than appending a nil IP.
+				continue
+			}
 			domain := strings.TrimSuffix(fields[0], ".")
-			resolved = append(resolved, net.ParseIP(fields[3]))
+			resolved = append(resolved, ip)
 			unresolved = slices.DeleteFunc(unresolved, func(hostname string) bool {
 				return strings.EqualFold(hostname, domain)
 			})

--- a/go/action_kit_commons/network/dnsresolve/resolve_test.go
+++ b/go/action_kit_commons/network/dnsresolve/resolve_test.go
@@ -118,6 +118,15 @@ no servers could be reached`, i...)
 	}
 }
 
+func TestHostnameResolver_rejects_hostnames_with_whitespace(t *testing.T) {
+	// Hostnames are written line-by-line into dig's stdin, so whitespace (esp. a newline)
+	// must be rejected rather than injecting an extra query.
+	for _, hostname := range []string{"evil.com\nqdisc-del", "with space", "tab\tname"} {
+		_, err := resolve(context.Background(), &mockDig{}, hostname)
+		assert.ErrorContains(t, err, "invalid hostnames", "hostname %q should be rejected", hostname)
+	}
+}
+
 type mockDig struct {
 	output []byte
 	err    error

--- a/go/action_kit_commons/network/netfault/bandwidth.go
+++ b/go/action_kit_commons/network/netfault/bandwidth.go
@@ -74,7 +74,7 @@ func (o *LimitBandwidthOpts) tcCommands(mode mode) ([]string, error) {
 	}
 	reorderForMode(cmds, mode)
 
-	if len(cmds)/len(o.Interfaces) > maxTcCommands {
+	if len(o.Interfaces) > 0 && len(cmds)/len(o.Interfaces) > maxTcCommands {
 		log.Trace().Strs("cmds", cmds).Msg("too many tc commands")
 		return nil, &ErrTooManyTcCommands{Count: len(cmds)}
 	}

--- a/go/action_kit_commons/network/netfault/delay.go
+++ b/go/action_kit_commons/network/netfault/delay.go
@@ -192,7 +192,7 @@ func (o *DelayOpts) tcCommands(mode mode) ([]string, error) {
 	}
 	reorderForMode(cmds, mode)
 
-	if len(cmds)/len(o.Interfaces) > maxTcCommands {
+	if len(o.Interfaces) > 0 && len(cmds)/len(o.Interfaces) > maxTcCommands {
 		log.Trace().Strs("cmds", cmds).Msg("too many tc commands")
 		return nil, &ErrTooManyTcCommands{Count: len(cmds)}
 	}

--- a/go/action_kit_commons/network/netfault/packageCorruption.go
+++ b/go/action_kit_commons/network/netfault/packageCorruption.go
@@ -65,7 +65,7 @@ func (o *CorruptPackagesOpts) tcCommands(mode mode) ([]string, error) {
 	}
 	reorderForMode(cmds, mode)
 
-	if len(cmds)/len(o.Interfaces) > maxTcCommands {
+	if len(o.Interfaces) > 0 && len(cmds)/len(o.Interfaces) > maxTcCommands {
 		log.Trace().Strs("cmds", cmds).Msg("too many tc commands")
 		return nil, &ErrTooManyTcCommands{Count: len(cmds)}
 	}

--- a/go/action_kit_commons/network/netfault/packageLoss.go
+++ b/go/action_kit_commons/network/netfault/packageLoss.go
@@ -64,7 +64,7 @@ func (o *PackageLossOpts) tcCommands(mode mode) ([]string, error) {
 	}
 	reorderForMode(cmds, mode)
 
-	if len(cmds)/len(o.Interfaces) > maxTcCommands {
+	if len(o.Interfaces) > 0 && len(cmds)/len(o.Interfaces) > maxTcCommands {
 		log.Trace().Strs("cmds", cmds).Msg("too many tc commands")
 		return nil, &ErrTooManyTcCommands{Count: len(cmds)}
 	}

--- a/go/action_kit_commons/network/netfault/runner_process.go
+++ b/go/action_kit_commons/network/netfault/runner_process.go
@@ -26,6 +26,9 @@ func (p processRunner) run(ctx context.Context, args []string, cmds []string) (s
 	cmd := utils.RootCommandContext(ctx, args[0], args[1:]...)
 	cmd.Stdout = &outb
 	cmd.Stderr = &errb
+	if rErr := validateBatchCommands(cmds); rErr != nil {
+		return "", rErr
+	}
 	cmd.Stdin = toReader(cmds)
 	err := cmd.Run()
 

--- a/go/action_kit_commons/network/netfault/runner_runc.go
+++ b/go/action_kit_commons/network/netfault/runner_runc.go
@@ -89,6 +89,9 @@ func (r *runcRunner) executeInNamedNetworkUsingIpNetNs(ctx context.Context, proc
 	cmd := utils.RootCommandContext(ctx, ipPath, ipArgs...)
 	cmd.Stdout = &outb
 	cmd.Stderr = &errb
+	if rErr := validateBatchCommands(cmds); rErr != nil {
+		return "", rErr
+	}
 	cmd.Stdin = toReader(cmds)
 	err := cmd.Run()
 
@@ -128,6 +131,9 @@ func (r *runcRunner) executeInNetworkNamespaceUsingRunc(ctx context.Context, pro
 		return "", err
 	}
 
+	if rErr := validateBatchCommands(cmds); rErr != nil {
+		return "", rErr
+	}
 	var outb, errb bytes.Buffer
 	err = r.runc.Run(ctx, bundle, ociruntime.IoOpts{
 		Stdin:  toReader(cmds),

--- a/go/action_kit_commons/network/netfault/utils.go
+++ b/go/action_kit_commons/network/netfault/utils.go
@@ -35,6 +35,19 @@ func toReader(strs []string) io.Reader {
 	return strings.NewReader(fmt.Sprintf("%s\n", strings.Join(strs, "\n")))
 }
 
+// validateBatchCommands rejects any command containing a newline before it is written to a
+// `tc`/`iptables` batch stdin. Each command must be exactly one directive; a newline would
+// split into extra batch directives, which is how an unsanitized interface name or rate
+// value forwarded from user input could inject an arbitrary privileged command.
+func validateBatchCommands(cmds []string) error {
+	for _, s := range cmds {
+		if strings.ContainsAny(s, "\n\r") {
+			return fmt.Errorf("refusing to build batch: command contains a newline (possible injection): %q", s)
+		}
+	}
+	return nil
+}
+
 func getFamily(net net.IPNet) (family, error) {
 	switch {
 	case net.IP.To4() != nil:

--- a/go/action_kit_commons/network/netfault/utils_test.go
+++ b/go/action_kit_commons/network/netfault/utils_test.go
@@ -10,6 +10,18 @@ import (
 	"github.com/steadybit/action-kit/go/action_kit_commons/network"
 )
 
+func Test_validateBatchCommands(t *testing.T) {
+	if err := validateBatchCommands([]string{"qdisc add dev eth0 root", "filter add dev eth0"}); err != nil {
+		t.Errorf("expected no error for clean commands, got %v", err)
+	}
+	if err := validateBatchCommands([]string{"qdisc add dev eth0 root\nqdisc del dev eth0 root"}); err == nil {
+		t.Error("expected an error for a command containing a newline (injection)")
+	}
+	if err := validateBatchCommands([]string{"ok", "bad\rvalue"}); err == nil {
+		t.Error("expected an error for a command containing a carriage return")
+	}
+}
+
 func Test_getMask(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/go/action_kit_commons/ociruntime/ociruntime.go
+++ b/go/action_kit_commons/ociruntime/ociruntime.go
@@ -290,7 +290,13 @@ func (r *defaultRuntime) Run(ctx context.Context, container ContainerBundle, ioO
 	log.Trace().Str("id", container.ContainerId()).Msg("running container")
 	err = cmd.Run()
 
-	log.Trace().Str("id", container.ContainerId()).Int("exitCode", cmd.ProcessState.ExitCode()).Msg("container exited")
+	// ProcessState is nil if the process never started (e.g. the runtime binary is
+	// missing), so guard the exit-code read to avoid a nil-pointer panic on that path.
+	exitCode := -1
+	if cmd.ProcessState != nil {
+		exitCode = cmd.ProcessState.ExitCode()
+	}
+	log.Trace().Str("id", container.ContainerId()).Int("exitCode", exitCode).Msg("container exited")
 	return err
 }
 
@@ -429,7 +435,7 @@ func unmarshalGuarded(output []byte, v any) error {
 		return nil
 	}
 
-	if output[0] != '{' && bytes.Contains(output, []byte("{")) && bytes.Contains(output, []byte("}")) {
+	if len(output) > 0 && output[0] != '{' && bytes.Contains(output, []byte("{")) && bytes.Contains(output, []byte("}")) {
 		if err := json.Unmarshal(output[bytes.IndexByte(output, '{'):], v); err == nil {
 			return nil
 		}

--- a/go/action_kit_commons/stress/stress_process.go
+++ b/go/action_kit_commons/stress/stress_process.go
@@ -34,6 +34,10 @@ func NewStressProcess(opts Opts) (Stress, error) {
 }
 
 func (s *stressProcess) Exited() (bool, error) {
+	if s.state == nil {
+		// Start was never called (or failed): there is no running process.
+		return true, nil
+	}
 	return s.state.Exited()
 }
 
@@ -52,14 +56,21 @@ func (s *stressProcess) Start() error {
 }
 
 func (s *stressProcess) Stop() {
+	if s.cmd.Process == nil || s.state == nil {
+		// never started (or start failed) — nothing to stop
+		return
+	}
 	//as the process is running with a different user, we also need to do so, for sending signals
 	ctx := context.Background()
-	if err := utils.RootCommandContext(ctx, "kill", "-s", "SIGINT", strconv.Itoa(s.cmd.Process.Pid)).Run(); err != nil {
+	// Capture the pid up front so the timer goroutine below doesn't read s.cmd.Process
+	// concurrently with the exec waiter.
+	pid := strconv.Itoa(s.cmd.Process.Pid)
+	if err := utils.RootCommandContext(ctx, "kill", "-s", "SIGINT", pid).Run(); err != nil {
 		log.Warn().Err(err).Msg("failed to send SIGINT to stress-ng")
 	}
 
 	timer := time.AfterFunc(10*time.Second, func() {
-		if err := utils.RootCommandContext(ctx, "kill", "-s", "SIGTERM", strconv.Itoa(s.cmd.Process.Pid)).Run(); err != nil {
+		if err := utils.RootCommandContext(ctx, "kill", "-s", "SIGTERM", pid).Run(); err != nil {
 			log.Warn().Err(err).Msg("failed to send SIGTERM to stress-ng")
 		}
 	})


### PR DESCRIPTION
## Summary

The final action-kit kit-audit item: robustness fixes across `action_kit_commons` (crash paths + privileged-command injection hardening). Grouped into cohesive commits; all in one PR per request.

## Fixes

**Crash / panic guards**
- `ociruntime`: `cmd.ProcessState.ExitCode()` is read right after `cmd.Run()` — nil-deref if the runtime binary never started; guard with a `-1` sentinel. `unmarshalGuarded` indexed `output[0]` with no length check — index panic on empty runtime output.
- `netfault` (`bandwidth`/`delay`/`packageLoss`/`packageCorruption`): `len(cmds)/len(o.Interfaces)` divide-by-zero when an attack has no interfaces; guarded with `len(o.Interfaces) > 0` (matching `tcp_reset`).
- process wrappers (`stress`/`memfill`/`diskfill`): `Exited()`/`Stop()` dereferenced the background state / exec `Process` that are only set on a successful `Start`, so calling them after a failed/absent `Start` panicked. Guarded — `Exited()` reports "exited" when never started, `Stop()` is a no-op.

**Injection hardening (defense-in-depth)**
- Commands go one-per-line to `tc`/`iptables -batch` stdin and hostnames one-per-line to `dig -f-`. A newline in an unsanitized **interface name / rate / hostname** forwarded from user input would inject an extra privileged directive/query. Reject any batch command containing a newline (single `validateBatchCommands` at the 3 runner choke points) and any hostname containing whitespace (at the dig-stdin sink). All `exec` already uses argv, so there's no shell-metachar injection; this closes the batch-stdin vector.
- Also: capture the pid before the SIGTERM timer goroutine (removes a data race with the exec waiter), and skip un-parseable IPs in DNS resolution instead of appending `nil`.

## Deliberately not changed / follow-ups

- **`ociruntime.ConfigFromEnvironment` keeps `log.Fatal`** — it's startup env-config parsing (unrecoverable misconfig, fail-fast is the codebase convention); changing it would ripple an `error` return through every caller. This PR is scoped to *runtime* crash paths.
- **Optional refactors** flagged by `/simplify`, not done here: extract the repeated stress/memfill/diskfill `Stop`/`Exited` block into a shared `utils.StopBackgroundProcess` helper; and express the netfault "≥1 interface" invariant once instead of four inline guards.
- The injection guard is **containment** (blocks directive injection); full input validation (interface charset, rate format) belongs upstream in the extensions, not this SDK.

## Verification

`go build ./...`, `go vet ./...`, `go test ./...` pass (module `go/action_kit_commons`). New tests: `validateBatchCommands` (newline/CR rejection) and dnsresolve whitespace-hostname rejection.
