### PR TITLE
fix(netfault): skip unaddressable anonymous-root children on qdisc restore

### DIFF
--- a/go/action_kit_commons/CHANGELOG.md
+++ b/go/action_kit_commons/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix(netfault): skip restoring children of an anonymous root qdisc during snapshot restore. On stock multi-queue NICs (e.g. AWS ENA `ens5`) the kernel attaches `mq 0:` with one `fq_codel 0: parent :N` per TX queue — all handle 0 and therefore unaddressable via RTNETLINK, so `Qdisc().Replace()` failed with ENOENT (`netlink receive: no such file or directory`) and the Stop of every network attack on such hosts reported "Failed to revert network settings" even though the network was reverted correctly. Skipping is lossless: the kernel re-attaches the identical default tree after `tc qdisc del root`.
+
 ## 1.10.1
 
 - fix: guard runtime crash paths — no nil-deref reading a process exit code when a runtime binary fails to start, no index panic parsing empty runtime output (`ociruntime`), no divide-by-zero when a netfault attack has no interfaces, and no nil-deref when a stress/memfill/diskfill process wrapper's `Exited`/`Stop` is called without a successful `Start`

--- a/go/action_kit_commons/network/netfault/snapshot.go
+++ b/go/action_kit_commons/network/netfault/snapshot.go
@@ -168,10 +168,22 @@ func isRootQdisc(q tc.Object) bool {
 // qdisc rather than calling Replace. We skip kernel-auto-managed kinds (mq,
 // clsact, ingress) because the kernel re-attaches them automatically after
 // `tc qdisc del root`; restoring them ourselves would race the kernel.
+//
+// We also skip children of an anonymous root (Parent major == 0): on stock
+// multi-queue NICs (e.g. AWS ENA) the kernel attaches `mq 0:` with one
+// `fq_codel 0: parent :N` per TX queue, all with handle 0. Handle-0 qdiscs
+// are unaddressable via RTNETLINK — tc_modify_qdisc resolves the parent via
+// qdisc_lookup(dev, TC_H_MAJ(clid)), which returns NULL for major 0, so
+// Replace fails with ENOENT. Skipping is lossless: a child of an anonymous
+// root is by definition kernel-created (anything user-tuned has addressable
+// handles), and the kernel re-creates it identically after `tc qdisc del
+// root`.
+//
 // Pure function — no side effects, no netlink calls — so the decision is
 // unit-testable without an actual RTNETLINK socket.
 func shouldSkipQdiscOnRestore(q tc.Object) bool {
-	return isKernelAutoManaged(q.Kind)
+	return isKernelAutoManaged(q.Kind) ||
+		(!isRootQdisc(q) && handleMajor(q.Parent) == 0)
 }
 
 // stripRuntimeStats zeros the kernel-counter fields on a tc.Object so it can

--- a/go/action_kit_commons/network/netfault/snapshot_fixtures_test.go
+++ b/go/action_kit_commons/network/netfault/snapshot_fixtures_test.go
@@ -105,6 +105,39 @@ func fixtureEksDefaultEth0(ifindex uint32) []tc.Object {
 	}}
 }
 
+// fixtureEc2EnaAnonymousMq models a stock EC2/EKS multi-queue ENA interface
+// (ens5) where nobody ever configured tc: the kernel's attach_default_qdiscs
+// creates `mq 0: root` plus one `fq_codel 0: parent :N` per TX queue, all
+// with handle 0. Handle-0 qdiscs are unaddressable via RTNETLINK
+// (tc_modify_qdisc resolves the parent via qdisc_lookup(dev, TC_H_MAJ(clid)),
+// which returns NULL for major 0), so restore must skip every entry — the
+// kernel re-attaches the identical tree after `tc qdisc del root` anyway.
+//
+// Reference: `tc qdisc show dev ens5` on Amazon Linux
+//
+//	qdisc mq 0: root
+//	qdisc fq_codel 0: parent :4 limit 10240p flows 1024 quantum 9015 ...
+//	qdisc fq_codel 0: parent :3 limit 10240p flows 1024 quantum 9015 ...
+//	qdisc fq_codel 0: parent :2 limit 10240p flows 1024 quantum 9015 ...
+//	qdisc fq_codel 0: parent :1 limit 10240p flows 1024 quantum 9015 ...
+func fixtureEc2EnaAnonymousMq(ifindex uint32, queues uint16) []tc.Object {
+	out := []tc.Object{{
+		Msg:       tc.Msg{Ifindex: ifindex, Handle: 0, Parent: tcHRoot},
+		Attribute: tc.Attribute{Kind: "mq"},
+	}}
+	for q := uint16(1); q <= queues; q++ {
+		out = append(out, tc.Object{
+			Msg: tc.Msg{Ifindex: ifindex, Handle: 0, Parent: handle(0, q)},
+			Attribute: tc.Attribute{Kind: "fq_codel", FqCodel: &tc.FqCodel{
+				Limit:   uint32Ptr(10240),
+				Flows:   uint32Ptr(1024),
+				Quantum: uint32Ptr(9015),
+			}},
+		})
+	}
+	return out
+}
+
 // fixtureBareMetalHtbWithClasses models a bare-metal Linux host with a
 // user-installed `htb` root and traffic-shaping classes. Used by some CNI
 // bandwidth plugins and by manual `tc` shaping. Preflight refuses this kind

--- a/go/action_kit_commons/network/netfault/snapshot_realistic_test.go
+++ b/go/action_kit_commons/network/netfault/snapshot_realistic_test.go
@@ -106,6 +106,48 @@ func TestRestorePlan_EksDefault(t *testing.T) {
 	assert.Equal(t, planCounts{skip: 1, replace: 0}, plan)
 }
 
+// TestRestorePlan_Ec2EnaAnonymousMq covers a stock EC2/EKS multi-queue ENA
+// interface: `mq 0: root` with one anonymous `fq_codel 0: parent :N` per TX
+// queue. Everything carries handle 0 because the kernel attached it all via
+// attach_default_qdiscs. Handle-0 parents cannot be resolved via RTNETLINK,
+// so Replace() on the children fails with ENOENT ("netlink receive: no such
+// file or directory") — observed in production as a Stop error on ens5. The
+// planner must skip the whole tree: the kernel re-attaches the identical
+// defaults after `tc qdisc del root`, so there is nothing to restore.
+func TestRestorePlan_Ec2EnaAnonymousMq(t *testing.T) {
+	const ens5 uint32 = 2
+	qdiscs := fixtureEc2EnaAnonymousMq(ens5, 4)
+
+	require.Len(t, qdiscs, 5, "fixture should have 1 mq root + 4 fq_codel children")
+	plan := planForInterface(qdiscs)
+	assert.Equal(t, planCounts{skip: 5, replace: 0}, plan, "anonymous mq tree must be skipped entirely on restore")
+}
+
+// TestShouldSkipQdiscOnRestore_AnonymousParentOnly pins the skip rule to
+// children of anonymous roots: a child whose Parent major is non-zero (the
+// GKE mq 8026: case) must still be replaced, and a root qdisc with handle 0
+// (the AKS fq_codel case) must still be replaced — Parent == TC_H_ROOT is
+// always addressable.
+func TestShouldSkipQdiscOnRestore_AnonymousParentOnly(t *testing.T) {
+	anonymousChild := tc.Object{
+		Msg:       tc.Msg{Ifindex: 2, Handle: 0, Parent: handle(0, 1)},
+		Attribute: tc.Attribute{Kind: "fq_codel"},
+	}
+	assert.True(t, shouldSkipQdiscOnRestore(anonymousChild), "child of anonymous root is unaddressable, skip")
+
+	anchoredChild := tc.Object{
+		Msg:       tc.Msg{Ifindex: 2, Handle: handle(0x802b, 0), Parent: handle(0x8026, 1)},
+		Attribute: tc.Attribute{Kind: "fq"},
+	}
+	assert.False(t, shouldSkipQdiscOnRestore(anchoredChild), "child under an explicit mq handle must be replaced")
+
+	anonymousRoot := tc.Object{
+		Msg:       tc.Msg{Ifindex: 2, Handle: 0, Parent: tcHRoot},
+		Attribute: tc.Attribute{Kind: "fq_codel"},
+	}
+	assert.False(t, shouldSkipQdiscOnRestore(anonymousRoot), "root fq_codel is addressable via TC_H_ROOT, replace it")
+}
+
 // TestRestorePlan_BareMetalHtb covers a host with a user-installed htb
 // shaper tree. In production this case is caught by preflight (htb is not
 // in safeRootQdiscKinds), so the snapshot path shouldn't run. The test


### PR DESCRIPTION
## Problem

On stock multi-queue NICs (e.g. AWS ENA `ens5`), stopping any network attack fails with:

```
Stop Error: Failed to revert network settings.
restore qdisc fq_codel on ens5: netlink receive: no such file or directory
restore qdisc fq_codel on ens5: netlink receive: no such file or directory
...
```

(observed on `demo-develop-demo`; one line per TX queue)

The default tree on such hosts is fully anonymous — nobody ever configured `tc`, so the kernel attached everything with handle 0 via `attach_default_qdiscs`:

```
qdisc mq 0: root
qdisc fq_codel 0: parent :1
qdisc fq_codel 0: parent :2
qdisc fq_codel 0: parent :3
qdisc fq_codel 0: parent :4
```

The snapshot captures this at Apply. At Revert, the replay calls `Qdisc().Replace()` on each `fq_codel` child with `Parent = 0x0000000N`. The kernel's `tc_modify_qdisc` resolves the parent via `qdisc_lookup(dev, TC_H_MAJ(clid))`, which returns NULL for major 0 → **ENOENT**. Handle-0 qdiscs are fundamentally unaddressable via RTNETLINK (same reason plain `tc` can't touch children of `mq 0:` without first replacing the root with an explicit handle). Neither `claimAutoManagedRootHandles` (no saved handle to claim) nor `reAnchorAutoManagedParents` (saved major 0 == live major 0) helps here.

The error is cosmetic-but-scary: the attack tree *was* removed and the kernel had already re-attached the identical defaults — but the Stop reports a failed revert to the platform.

## Fix

Extend `shouldSkipQdiscOnRestore` to also skip non-root qdiscs whose Parent major is 0. This is lossless: a child of an anonymous root is by definition kernel-created (anything user-tuned has addressable handles), and the kernel re-creates it identically after `tc qdisc del root`.

Unaffected paths:
- GKE case (`mq 8026:` root with tuned `fq` children): parent majors are non-zero → still replaced.
- AKS case (root `fq_codel`, handle 0, parent `TC_H_ROOT`): roots are always addressable → still replaced.
- Children re-anchored by `reAnchorAutoManagedParents` onto a claimed live root: skip check runs on the rewritten (non-zero) parent → still restored.

## Tests

- New fixture `fixtureEc2EnaAnonymousMq` modeling the stock ENA tree (`mq 0:` + N anonymous `fq_codel` children) — this shape was missing from the fixture set (the EKS fixture only modeled a lone `pfifo_fast` root).
- `TestRestorePlan_Ec2EnaAnonymousMq`: whole tree is skipped.
- `TestShouldSkipQdiscOnRestore_AnonymousParentOnly`: pins the boundary — anonymous child skipped, explicitly-anchored child replaced, anonymous root replaced.

All 143 netfault tests pass; linux cross-build + vet clean.