### PR TITLE
feat: pass reserve, adaptive and oom_score_adj flags to memfill

### DIFF
--- a/go/action_kit_commons/memfill/memfill.go
+++ b/go/action_kit_commons/memfill/memfill.go
@@ -7,6 +7,7 @@ package memfill
 import (
 	"fmt"
 	"github.com/steadybit/action-kit/go/action_kit_commons/utils"
+	"strconv"
 	"time"
 )
 
@@ -33,6 +34,14 @@ type Opts struct {
 	Unit         Unit
 	Duration     time.Duration
 	IgnoreCgroup bool
+	// Reserve is the minimum memory to keep available (e.g. "512MiB"). Empty means no reserve.
+	// In usage mode it floors the memory left free; in absolute mode it caps the allocation.
+	Reserve string
+	// Adaptive frees memory when the host is under memory pressure (Linux PSI). Usage mode only.
+	Adaptive bool
+	// OomScoreAdj, when set, is the oom_score_adj (-1000..1000) applied to the fill process.
+	// Host fills should pass a high value so the OOM killer targets the fill, not the kubelet.
+	OomScoreAdj *int
 }
 
 func (o Opts) processArgs() []string {
@@ -40,6 +49,15 @@ func (o Opts) processArgs() []string {
 	args := []string{path, fmt.Sprintf("%d%s", o.Size, o.Unit), string(o.Mode), fmt.Sprintf("%.0f", o.Duration.Seconds())}
 	if o.IgnoreCgroup {
 		args = append(args, "--ignore-cgroup")
+	}
+	if o.Reserve != "" {
+		args = append(args, "--reserve", o.Reserve)
+	}
+	if o.Adaptive {
+		args = append(args, "--adaptive")
+	}
+	if o.OomScoreAdj != nil {
+		args = append(args, "--oom-score-adj", strconv.Itoa(*o.OomScoreAdj))
 	}
 	return args
 }

--- a/go/action_kit_commons/memfill/memfill_test.go
+++ b/go/action_kit_commons/memfill/memfill_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Steadybit GmbH
+//go:build !windows
+
+package memfill
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessArgs(t *testing.T) {
+	t.Setenv("STEADYBIT_EXTENSION_MEMFILL_PATH", "/usr/bin/memfill")
+
+	t.Run("minimal usage args, no optional flags", func(t *testing.T) {
+		args := Opts{Size: 100, Mode: ModeUsage, Unit: UnitPercent, Duration: 120 * time.Second}.processArgs()
+		assert.Equal(t, []string{"/usr/bin/memfill", "100%", "usage", "120"}, args)
+	})
+
+	t.Run("reserve, adaptive and oom_score_adj are appended in order", func(t *testing.T) {
+		score := 500
+		args := Opts{
+			Size: 100, Mode: ModeUsage, Unit: UnitPercent, Duration: 90 * time.Second,
+			Reserve: "512MiB", Adaptive: true, OomScoreAdj: &score,
+		}.processArgs()
+		assert.Equal(t, []string{
+			"/usr/bin/memfill", "100%", "usage", "90",
+			"--reserve", "512MiB", "--adaptive", "--oom-score-adj", "500",
+		}, args)
+	})
+
+	t.Run("negative oom_score_adj is rendered", func(t *testing.T) {
+		score := -998
+		args := Opts{Size: 1024, Mode: ModeAbsolute, Unit: UnitMegabyte, Duration: 10 * time.Second, OomScoreAdj: &score}.processArgs()
+		assert.Equal(t, []string{"/usr/bin/memfill", "1024MiB", "absolute", "10", "--oom-score-adj", "-998"}, args)
+	})
+
+	t.Run("optional flags are omitted when unset", func(t *testing.T) {
+		args := Opts{Size: 50, Mode: ModeUsage, Unit: UnitPercent, Duration: 5 * time.Second, IgnoreCgroup: true}.processArgs()
+		assert.Contains(t, args, "--ignore-cgroup")
+		assert.NotContains(t, args, "--reserve")
+		assert.NotContains(t, args, "--adaptive")
+		assert.NotContains(t, args, "--oom-score-adj")
+	})
+}

--- a/go/action_kit_commons/memfill/memfill_test.go
+++ b/go/action_kit_commons/memfill/memfill_test.go
@@ -39,9 +39,7 @@ func TestProcessArgs(t *testing.T) {
 
 	t.Run("optional flags are omitted when unset", func(t *testing.T) {
 		args := Opts{Size: 50, Mode: ModeUsage, Unit: UnitPercent, Duration: 5 * time.Second, IgnoreCgroup: true}.processArgs()
-		assert.Contains(t, args, "--ignore-cgroup")
-		assert.NotContains(t, args, "--reserve")
-		assert.NotContains(t, args, "--adaptive")
-		assert.NotContains(t, args, "--oom-score-adj")
+		// Exact match: --ignore-cgroup present, and none of --reserve/--adaptive/--oom-score-adj.
+		assert.Equal(t, []string{"/usr/bin/memfill", "50%", "usage", "5", "--ignore-cgroup"}, args)
 	})
 }


### PR DESCRIPTION
## What
Extends `memfill.Opts` (`go/action_kit_commons/memfill`) with the flags added in **memfill 1.4.0**, and emits them in `processArgs`:

- `Reserve string` → `--reserve <val>` — minimum memory to keep available (usage mode floors the free memory; absolute mode caps the allocation).
- `Adaptive bool` → `--adaptive` — free memory under Linux PSI pressure (usage mode only).
- `OomScoreAdj *int` → `--oom-score-adj <n>` — oom_score_adj for the fill process (nil = memfill's default).

All optional; existing callers are unaffected (empty/false/nil ⇒ flags omitted).

## Why
So a **host** memory fill (extension-host) can drive maximum pressure without starving the OS/kubelet and taking the node NotReady: leave a `--reserve` (e.g. 512 MiB), `--adaptive` back-off, and a high `--oom-score-adj` so the OOM killer targets the fill rather than critical processes.

## Testing
- `go build ./...`, `go vet`, `gofmt` clean.
- New `memfill_test.go` covers `processArgs`: minimal args, all three flags appended in order, negative oom_score_adj, and omission when unset.

Next: extension-host consumes these (default reserve 512 MiB, `--adaptive`, internal high `oom_score_adj`). Part of the fill_mem node-safety work (ADM-1970).