### PR TITLE
fix: network attacks now affect portless protocols (e.g. ICMP)

### DIFF
--- a/go/action_kit_commons/network/netfault/blackhole.go
+++ b/go/action_kit_commons/network/netfault/blackhole.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+
+	"github.com/steadybit/action-kit/go/action_kit_commons/network"
 )
 
 type IpProto string
@@ -62,8 +64,8 @@ func (o *BlackholeOpts) ipCommands(family family, mode mode) ([]string, error) {
 			continue
 		}
 
-		cmds = append(cmds, fmt.Sprintf("rule %s blackhole to %s%s dport %s", mode, net.String(), ipprotoSelector, portRange.String()))
-		cmds = append(cmds, fmt.Sprintf("rule %s blackhole from %s%s sport %s", mode, net.String(), ipprotoSelector, portRange.String()))
+		cmds = append(cmds, fmt.Sprintf("rule %s blackhole to %s%s%s", mode, net.String(), ipprotoSelector, portSelector("dport", portRange)))
+		cmds = append(cmds, fmt.Sprintf("rule %s blackhole from %s%s%s", mode, net.String(), ipprotoSelector, portSelector("sport", portRange)))
 	}
 
 	for _, nwp := range filter.Exclude {
@@ -76,11 +78,22 @@ func (o *BlackholeOpts) ipCommands(family family, mode mode) ([]string, error) {
 			continue
 		}
 
-		cmds = append(cmds, fmt.Sprintf("rule %s to %s%s dport %s table main", mode, net.String(), ipprotoSelector, portRange.String()))
-		cmds = append(cmds, fmt.Sprintf("rule %s from %s%s sport %s table main", mode, net.String(), ipprotoSelector, portRange.String()))
+		cmds = append(cmds, fmt.Sprintf("rule %s to %s%s%s table main", mode, net.String(), ipprotoSelector, portSelector("dport", portRange)))
+		cmds = append(cmds, fmt.Sprintf("rule %s from %s%s%s table main", mode, net.String(), ipprotoSelector, portSelector("sport", portRange)))
 	}
 	reorderForMode(cmds, mode)
 	return cmds, nil
+}
+
+// portSelector renders the ` dport <range>` / ` sport <range>` fragment for an
+// ip rule. For PortRangeAny it returns an empty string so the rule matches all
+// traffic regardless of L4 port — otherwise portless protocols such as ICMP
+// would never match a `dport`/`sport` selector and escape the blackhole.
+func portSelector(keyword string, portRange network.PortRange) string {
+	if portRange.IsAny() {
+		return ""
+	}
+	return fmt.Sprintf(" %s %s", keyword, portRange.String())
 }
 
 func (o *BlackholeOpts) String() string {

--- a/go/action_kit_commons/network/netfault/blackhole_test.go
+++ b/go/action_kit_commons/network/netfault/blackhole_test.go
@@ -40,25 +40,25 @@ func TestBlackholeOpts_IpCommands(t *testing.T) {
 					},
 				},
 			},
-			wantAddV4: []byte(`rule add blackhole to 0.0.0.0/0 dport 1-65534
-rule add blackhole from 0.0.0.0/0 sport 1-65534
+			wantAddV4: []byte(`rule add blackhole to 0.0.0.0/0
+rule add blackhole from 0.0.0.0/0
 rule add to 192.168.2.1/32 dport 80 table main
 rule add from 192.168.2.1/32 sport 80 table main
 `),
 			wantDelV4: []byte(`rule del from 192.168.2.1/32 sport 80 table main
 rule del to 192.168.2.1/32 dport 80 table main
-rule del blackhole from 0.0.0.0/0 sport 1-65534
-rule del blackhole to 0.0.0.0/0 dport 1-65534
+rule del blackhole from 0.0.0.0/0
+rule del blackhole to 0.0.0.0/0
 `),
-			wantAddV6: []byte(`rule add blackhole to ::/0 dport 1-65534
-rule add blackhole from ::/0 sport 1-65534
+			wantAddV6: []byte(`rule add blackhole to ::/0
+rule add blackhole from ::/0
 rule add to ff02::114/128 dport 8000-8999 table main
 rule add from ff02::114/128 sport 8000-8999 table main
 `),
 			wantDelV6: []byte(`rule del from ff02::114/128 sport 8000-8999 table main
 rule del to ff02::114/128 dport 8000-8999 table main
-rule del blackhole from ::/0 sport 1-65534
-rule del blackhole to ::/0 dport 1-65534
+rule del blackhole from ::/0
+rule del blackhole to ::/0
 `),
 			wantErr: false,
 		},
@@ -84,6 +84,32 @@ rule add blackhole from ::/0 ipproto udp sport 123
 `),
 			wantDelV6: []byte(`rule del blackhole from ::/0 ipproto udp sport 123
 rule del blackhole to ::/0 ipproto udp dport 123
+`),
+			wantErr: false,
+		},
+		{
+			// No port specified => PortRangeAny => rule must omit dport/sport so
+			// that portless protocols (e.g. ICMP) are blackholed as well.
+			name: "blackhole a single host on all protocols when no port specified",
+			opts: BlackholeOpts{
+				Filter: Filter{
+					Include: []network.NetWithPortRange{
+						mustParseNetWithPortRange("10.0.0.5/32", "*"),
+						mustParseNetWithPortRange("2001:db8::5/128", "*"),
+					},
+				},
+			},
+			wantAddV4: []byte(`rule add blackhole to 10.0.0.5/32
+rule add blackhole from 10.0.0.5/32
+`),
+			wantDelV4: []byte(`rule del blackhole from 10.0.0.5/32
+rule del blackhole to 10.0.0.5/32
+`),
+			wantAddV6: []byte(`rule add blackhole to 2001:db8::5/128
+rule add blackhole from 2001:db8::5/128
+`),
+			wantDelV6: []byte(`rule del blackhole from 2001:db8::5/128
+rule del blackhole to 2001:db8::5/128
 `),
 			wantErr: false,
 		},

--- a/go/action_kit_commons/network/netfault/delay.go
+++ b/go/action_kit_commons/network/netfault/delay.go
@@ -147,7 +147,7 @@ func buildSingleIptables(nwp network.NetWithPortRange, isDst bool, isExclude boo
 	sb.WriteString(" ")
 
 	// Port match if not any
-	if nwp.PortRange != network.PortRangeAny {
+	if !nwp.PortRange.IsAny() {
 		if isDst {
 			sb.WriteString("--dport ")
 		} else {

--- a/go/action_kit_commons/network/netfault/utils.go
+++ b/go/action_kit_commons/network/netfault/utils.go
@@ -147,7 +147,7 @@ func getMatchers(nwp network.NetWithPortRange) ([]string, error) {
 const portMaxValue uint16 = 0xffff
 
 func getMask(r network.PortRange) []string {
-	if r == network.PortRangeAny {
+	if r.IsAny() {
 		return []string{"0 0x0000"}
 	} else if r.From == r.To {
 		return []string{fmt.Sprintf("%d 0xffff", r.From)}

--- a/go/action_kit_commons/network/types.go
+++ b/go/action_kit_commons/network/types.go
@@ -33,6 +33,13 @@ func (p *PortRange) String() string {
 	return fmt.Sprintf("%d-%d", p.From, p.To)
 }
 
+// IsAny reports whether the range is the "any port" wildcard (PortRangeAny).
+// Callers use this to decide whether to emit a port selector at all — a rule
+// scoped to "any port" must match portless protocols such as ICMP too.
+func (p *PortRange) IsAny() bool {
+	return *p == PortRangeAny
+}
+
 func (p *PortRange) Merge(other PortRange) PortRange {
 	return PortRange{From: min(p.From, other.From), To: max(p.To, other.To)}
 }
@@ -144,7 +151,7 @@ type NetWithPortRange struct {
 func (nwp NetWithPortRange) String() string {
 	var sb strings.Builder
 	sb.WriteString(nwp.Net.String())
-	if nwp.PortRange != PortRangeAny {
+	if !nwp.PortRange.IsAny() {
 		sb.WriteString(" ")
 		sb.WriteString(nwp.PortRange.String())
 	}


### PR DESCRIPTION
## What

Network attacks did not affect protocols without ports (e.g. ICMP) when no port was specified.

When the caller leaves the port unset, extensions default the filter to the any-port wildcard `PortRangeAny` (`{1, 65534}`). The `blackhole` attack, however, **always** appended a `dport`/`sport` selector to the generated `ip rule`, so `PortRangeAny` rendered as `dport 1-65534`. An `ip rule` with `dport`/`sport` only matches port-bearing protocols (TCP/UDP/SCTP), so ICMP and other portless traffic escaped the blackhole.

This was introduced with the `ip rule`-based blackhole implementation. The other backends were already correct: the `tc`/u32 path renders the wildcard as a zero-mask (`0 0x0000`) that matches everything, and the iptables delay path already guarded on the wildcard before emitting a port match — `blackhole` was the outlier that forgot the guard.

## Change

- `fix`: omit the `dport`/`sport` selector for the any-port wildcard in the blackhole `ip rule`, so it matches all protocols including ICMP. Specific port ranges and explicit `ipproto` selectors are unchanged.
- `refactor`: introduce `PortRange.IsAny()` and replace the open-coded `== PortRangeAny` comparisons across the netfault backends, keeping the wildcard definition in one place (this is the guard blackhole had been missing).

## Tests

- Updated `blackhole_test.go`: any-port rules now assert no `dport`/`sport`; specific-port and `ipproto udp` cases unchanged; added a dedicated portless (ICMP) case.
- End-to-end ICMP coverage (ping) is added in the extension-host and extension-container blackhole e2e suites in their respective repos.

Ref: BusinessMap 13054
