### PR TITLE
fix(netfault): report repeated tc batch errors only once

### DIFF
--- a/go/action_kit_commons/network/netfault/batch_error.go
+++ b/go/action_kit_commons/network/netfault/batch_error.go
@@ -48,10 +48,23 @@ func (t *batchError) Error() string {
 }
 
 func (t *batchErrors) Error() string {
+	occurrences := make(map[string]int)
+	for _, err := range t.Errors {
+		occurrences[err.Msg]++
+	}
+
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("Command failed %s\n", strings.Join(t.Cmd, " ")))
+	reported := make(map[string]bool)
 	for _, err := range t.Errors {
+		if reported[err.Msg] {
+			continue
+		}
+		reported[err.Msg] = true
 		sb.WriteString(err.Error())
+		if count := occurrences[err.Msg]; count > 1 {
+			sb.WriteString(fmt.Sprintf(" (and %d more)", count-1))
+		}
 		sb.WriteString("\n")
 	}
 	return sb.String()

--- a/go/action_kit_commons/network/netfault/batch_error_test.go
+++ b/go/action_kit_commons/network/netfault/batch_error_test.go
@@ -32,6 +32,23 @@ Error: Parent Qdisc doesn't exists.
 We have an error talking to the kernel
 Command failed -:3
 `
+	exampleErrorRepeated := `Error: NLM_F_REPLACE needed to override.
+Command failed -:1
+Error: Failed to find specified qdisc.
+Command failed -:2
+Error: Parent Qdisc doesn't exists.
+We have an error talking to the kernel
+Command failed -:3
+Error: Parent Qdisc doesn't exists.
+We have an error talking to the kernel
+Command failed -:4
+Error: Parent Qdisc doesn't exists.
+We have an error talking to the kernel
+Command failed -:5
+Error: Parent Qdisc doesn't exists.
+We have an error talking to the kernel
+Command failed -:6
+`
 
 	tests := []struct {
 		name   string
@@ -56,10 +73,33 @@ Command failed -:3
 			},
 			assert: func(t assert.TestingT, err error, message string) {
 				assert.Equal(t, 3, len(err.(*batchErrors).Errors))
-				assert.Equal(t, exampleError, strings.TrimPrefix(err.Error(), "Command failed test -b -\n"))
+				assert.Equal(t, `Error: Exclusivity flag on, cannot modify.
+Command failed -:1 (and 1 more)
+RTNETLINK answers: File exists
+Command failed -:2
+`, strings.TrimPrefix(err.Error(), "Command failed test -b -\n"))
 				assert.Equal(t, "Error: Exclusivity flag on, cannot modify.", err.(*batchErrors).Errors[0].Msg)
 				assert.Equal(t, "RTNETLINK answers: File exists", err.(*batchErrors).Errors[1].Msg)
 				assert.Equal(t, "Error: Exclusivity flag on, cannot modify.", err.(*batchErrors).Errors[2].Msg)
+			},
+		},
+		{
+			name: "should report repeated errors only once",
+			args: args{
+				cmd: []string{"tc", "-force", "-batch", "-"},
+				r:   strings.NewReader(exampleErrorRepeated),
+			},
+			assert: func(t assert.TestingT, err error, message string) {
+				assert.Equal(t, 6, len(err.(*batchErrors).Errors))
+				assert.Equal(t, `Command failed tc -force -batch -
+Error: NLM_F_REPLACE needed to override.
+Command failed -:1
+Error: Failed to find specified qdisc.
+Command failed -:2
+Error: Parent Qdisc doesn't exists.
+We have an error talking to the kernel
+Command failed -:3 (and 3 more)
+`, err.Error())
 			},
 		},
 		{


### PR DESCRIPTION
## Context

Businessmap ticket 12109: running a network delay attack on a custom Ubuntu image showed the same error message many times in the action's error details.

`tc -force -batch` reports one error per failed batch line. Since a delay attack installs many filter rules, the rendered error repeated `Error: Parent Qdisc doesn't exists. / We have an error talking to the kernel` once per rule.

## Change

Deduplicate identical messages when rendering `batchErrors`: the first occurrence is kept and repeats collapse into an `(and N more)` suffix on its `Command failed -:<line>` line.

The parsed error list itself is unchanged — `filterBatchErrors` ignore handling and the kernel-config hints behave exactly as before.

Example output after this change:

```
Command failed tc -force -batch -
Error: NLM_F_REPLACE needed to override.
Command failed -:1
Error: Failed to find specified qdisc.
Command failed -:2
Error: Parent Qdisc doesn't exists.
We have an error talking to the kernel
Command failed -:3 (and 11 more)
```

Extensions (extension-container, extension-host) pick this up via a regular `action_kit_commons` dependency bump — no changes needed there.